### PR TITLE
set release on native crash sdk 2.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ create_release:
 	sentry-cli releases -o $(SENTRY_ORG) new -p $(SENTRY_PROJECT) $(RELEASE)
 
 associate_commits:
-	sentry-cli releases --log-level debug -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) set-commits --auto $(RELEASE)
+	sentry-cli releases -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) set-commits --auto $(RELEASE)
 
 clean:
 	./gradlew clean build

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ create_release:
 	sentry-cli releases -o $(SENTRY_ORG) new -p $(SENTRY_PROJECT) $(RELEASE)
 
 associate_commits:
-	sentry-cli releases -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) set-commits --auto $(RELEASE)
+	sentry-cli releases --log-level debug -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) set-commits --auto $(RELEASE)
 
 clean:
 	./gradlew clean build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SENTRY_ORG=testorg-az
-SENTRY_PROJECT=android
+SENTRY_PROJECT=paranoid-android
 RELEASE=`sentry-cli releases propose-version`
 
 all: gradle_build setup_release

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Additional documentation:
 
 1. `git clone git@github.com:sentry-demos/android.git`
 
-2. Open project using Android Studio
+2. Open project using Android Studio and set your Build Variant to 'release' instead of debug.
 
 3. Sync the project with the Gradle files
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Additional documentation:
 
 4. Put your Sentry DSN key in `AndroidManifest.xml` and your 'project' name in the Makefile
 
-5. Put your AUTH Token in sentry.properties
+5. Put your AUTH Token and project name in sentry.properties
 
 6. `make all`
 
-7. Android Studio install ANdroid NDK in Preferences > System & Behavior > System Settings > Android SDK > SDK Tools > select NDK for download
+7. Android Studio install Android NDK in Preferences > System & Behavior > System Settings > Android SDK > SDK Tools > select NDK for download
 
 You can see debug files were uploaded in your Project Settings
 ![gif](screenshots/debug-information-files-settings.png)

--- a/README.md
+++ b/README.md
@@ -121,5 +121,5 @@ This would make for a release of `1.1.0 (11) com.example.vu@androidh1.2+11`. The
 The info in AndroidManifest.xml will override what's in build.gradle.
 
 **Other**
-Sometimes you'll see extra ANR events, because you have setting set to 3seconds
-Hard to compare Total Number of Crashes to a report in Discover on handled:no and the release, because when a crash happens, you have to wait for the device to come back online again. There are some other technical reasons as well, which are still being sorted out.
+Sometimes you'll see extra ANR events, because you have setting set to 3 seconds
+Hard to compare Total Number of Crashes to a report in Discover on handled:no and the release, because when a crash happens, you have to wait for the device to come back online again. There are some other technical reasons as well, which are still being sorted out. For instance, if you're evering filtering, sampling or Rate Limiting events/crashes out, then it's possible that the Sessions data isn ot getting filtered/sampled and so your Crash Free rate will appear higher than it actually is.

--- a/README.md
+++ b/README.md
@@ -98,25 +98,17 @@ In this case, you can fix that by updating Sentry's server. To do that:
 
 ![Native Crash](android-native-crash-take-1.gif)
 
-## Design
-
-font is 'Rubik'
-https://fonts.google.com/specimen/Rubik
-https://developer.android.com/guide/topics/ui/look-and-feel/fonts-in-xml
-
-store the ~/Downloads/android-assets
-
-
-## TODO
-1.
+## Technical Notes
+**Release Technique #1**
+Setting the release here is good if you really had a reason to override, eg. Paid vs Free versions of your apps
+This is not generally for a customer. It's for testing so I can quickly iterate new releases while I'm testing.
+```
 <meta-data android:name="io.sentry.release" android:value="io.sentry.sample@1.0.0+1" />
-^ But this is good if you really had a reason to override, eg. Paid vs Free versions of your apps
-^ not generally for customer.x just for testing so I get a new Release# when i'm testing.
+```
 
-vs.
-
-2.
+**Release Technique #2**
 Release was being done here:
+```
 build.gradle
 defaultConfig {
     applicationId "com.example.vu.android"
@@ -124,17 +116,10 @@ defaultConfig {
     targetSdkVersion 29
     versionCode 11
     versionName "1.2"
-- ^ this would make for a release of `1.1.0 (11) com.example.vu@androidh1.2+11`
-- the version code is unique
-- this is already part of build system o Android. app won't compile without to.
+```
+This would make for a release of `1.1.0 (11) com.example.vu@androidh1.2+11`. The version code is unique. This is already part of build system o Android. app won't compile without to.
+The info in AndroidManifest.xml will override what's in build.gradle.
 
-the info in AndroidManifest.xml will override what's in build.gradle
-
-
-
-
-2.1.1 fixed putting the Release in the App
-"we always set the release of the version that it was running on"
-
-
-sometimes you'll see extra ANR events, because you have setting set to 3seconds
+**Other**
+Sometimes you'll see extra ANR events, because you have setting set to 3seconds
+Hard to compare Total Number of Crashes to a report in Discover on handled:no and the release, because when a crash happens, you have to wait for the device to come back online again. There are some other technical reasons as well, which are still being sorted out.

--- a/README.md
+++ b/README.md
@@ -105,3 +105,36 @@ https://fonts.google.com/specimen/Rubik
 https://developer.android.com/guide/topics/ui/look-and-feel/fonts-in-xml
 
 store the ~/Downloads/android-assets
+
+
+## TODO
+1.
+<meta-data android:name="io.sentry.release" android:value="io.sentry.sample@1.0.0+1" />
+^ But this is good if you really had a reason to override, eg. Paid vs Free versions of your apps
+^ not generally for customer.x just for testing so I get a new Release# when i'm testing.
+
+vs.
+
+2.
+Release was being done here:
+build.gradle
+defaultConfig {
+    applicationId "com.example.vu.android"
+    minSdkVersion 21
+    targetSdkVersion 29
+    versionCode 11
+    versionName "1.2"
+- ^ this would make for a release of `1.1.0 (11) com.example.vu@androidh1.2+11`
+- the version code is unique
+- this is already part of build system o Android. app won't compile without to.
+
+the info in AndroidManifest.xml will override what's in build.gradle
+
+
+
+
+2.1.1 fixed putting the Release in the App
+"we always set the release of the version that it was running on"
+
+
+sometimes you'll see extra ANR events, because you have setting set to 3seconds

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
-    implementation 'io.sentry:sentry-android:2.1.0-beta.1'
+    implementation 'io.sentry:sentry-android:2.1.1'
 }
 
 sentry {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,11 +31,20 @@
             android:value="https://80b8a795d2a14cf796acaae4fa6cab30@o87286.ingest.sentry.io/261820"/>
         <meta-data android:name="io.sentry.debug" android:value="true" />
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
-        <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="2000" />
 
-        <meta-data android:name="io.sentry.release" android:value="io.sentry.sample@1.0.0+1" />
-        <meta-data android:name="io.sentry.session-tracking.enable" android:value="true" />
+        <!-- Default is 5seconds but we do 2 seconds for testing and demo's -->
+        <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="3000" />
 
+        <!-- Easy way to get a new release if you're testing, to separate from past releases with lots of crashes/sessions. overrides what's in app/build.gradle -->
+        <!-- <meta-data android:name="io.sentry.release" android:value="io.sentry.sample@1.0.0+1" />-->
+
+        <!-- default interval for testing a session is 30seconds. Session starts when they open app. Session ends when user leaves app and it's idle for 30 seconds -->
+        <meta-data android:name="io.sentry.session-tracking.timeout-interval-millis" android:value="3000" />
+
+        <!-- Enables automatic session tracking. Disabled by default because back-end is not GA yet. SDK is GA. works for us for testing right now -->
+        <!-- <meta-data android:name="io.sentry.session-tracking.enable" android:value="true" />-->
+
+<!-- these are enabled by default, these are optional for us to disable the feature -->
 <!--    <meta-data android:name="io.sentry.ndk.enable" android:value="false" />
         <meta-data android:name="io.sentry.anr.enable" android:value="false" />
 -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         </activity>
 
         <meta-data android:name="io.sentry.dsn"
-            android:value="https://3d2ac63d6e1a4c6e9214443678f119a3@o87286.ingest.sentry.io/1801383"/>
+            android:value="https://80b8a795d2a14cf796acaae4fa6cab30@o87286.ingest.sentry.io/261820"/>
         <meta-data android:name="io.sentry.debug" android:value="true" />
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
         <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="2000" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         </activity>
 
         <meta-data android:name="io.sentry.dsn"
-            android:value="https://80b8a795d2a14cf796acaae4fa6cab30@o87286.ingest.sentry.io/261820"/>
+            android:value="https://3d2ac63d6e1a4c6e9214443678f119a3@o87286.ingest.sentry.io/1801383"/>
         <meta-data android:name="io.sentry.debug" android:value="true" />
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,9 @@
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
         <meta-data android:name="io.sentry.anr.timeout-interval-mills" android:value="2000" />
 
+        <meta-data android:name="io.sentry.release" android:value="io.sentry.sample@1.0.0+1" />
+        <meta-data android:name="io.sentry.session-tracking.enable" android:value="true" />
+
 <!--    <meta-data android:name="io.sentry.ndk.enable" android:value="false" />
         <meta-data android:name="io.sentry.anr.enable" android:value="false" />
 -->

--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -25,7 +25,7 @@ public class MyApplication extends Application {
 
                 //Remove PII
                 List<SentryException> exceptions = event.getExceptions();
-                if(exceptions.size() > 0){
+                if(exceptions != null && exceptions.size() > 0){
                     SentryException exception = exceptions.get(0);
                     if(exception.getType().contains("NegativeArraySizeException")){
                         User user = event.getUser();

--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -20,14 +20,17 @@ public class MyApplication extends Application {
 
             // This callback is used before the event is sent to Sentry.
             // You can modify the event or, when returning null, also discard the event.
-            options.setEnableSessionTracking(true);
+
+            // we now enable this in AndroidManifest.xml
+            // options.setEnableSessionTracking(true);
+
             options.setBeforeSend((event, hint) -> {
 
                 //Remove PII
                 List<SentryException> exceptions = event.getExceptions();
                 if(exceptions != null && exceptions.size() > 0){
                     SentryException exception = exceptions.get(0);
-                    if(exception.getType().contains("NegativeArraySizeException")){
+                    if("NegativeArraySizeException".equals(exception.getType())) {
                         User user = event.getUser();
                         user.setIpAddress(null);
                     }

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,4 @@
 # how a sentry.properties looks like
 defaults.org=testorg-az
 defaults.project=android
-auth.token=ad03024943b44576b58a9c511caa610a1d3c6a69de514a5286723fb6e7109b0d
+auth.token=

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,4 @@
 # how a sentry.properties looks like
 defaults.org=testorg-az
 defaults.project=android
-auth.token=37cd3838bb554839a44d6f2a843b8a305371d3212940455099257440f64b8c2c
+auth.token=ad03024943b44576b58a9c511caa610a1d3c6a69de514a5286723fb6e7109b0d

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,4 @@
 # how a sentry.properties looks like
 defaults.org=testorg-az
-defaults.project=paranoid-android
-auth.token=
+defaults.project=android
+auth.token=37cd3838bb554839a44d6f2a843b8a305371d3212940455099257440f64b8c2c

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,4 @@
 # how a sentry.properties looks like
 defaults.org=testorg-az
-defaults.project=android
+defaults.project=paranoid-android
 auth.token=


### PR DESCRIPTION
- v2.1.1 SDK now allows Release to have a version number
- added a section about two different ways to specify the Release
- added a 'Technical Notes' section for some gotcha's that Manoel explained, regarding Crash counts