### PR TITLE
Experiment - Performance Transaction set Manually

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
-    implementation 'io.sentry:sentry-android:3.1.0'
+    implementation 'io.sentry:sentry-android:3.2.0'
 }
 
 sentry {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
-    implementation 'io.sentry:sentry-android:3.2.0'
+    implementation 'io.sentry:sentry-android:4.0.0-alpha.2'
 }
 
 sentry {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
         <meta-data android:name="io.sentry.debug" android:value="true" />
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
+        <!-- how to enable Transactions and set a sampleRate (anything between 0.01 and 1.0), it's disabled by default-->
+        <meta-data android:name="io.sentry.traces-sample-rate" android:value="1.0" />
+
 <!--        This line not needed any more, because now we have a safe guard, waiting for the Operating System to raise an ANR in the processor, it waits 5seconds. Lowering this number just makes it to check the state of the processor more times.-->
 <!--        lowering this number below 5000ms overrides the 5000ms, we check the state of the processor faster. doesn't mean we're detecting more ANR's or not-->
 

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import io.sentry.Breadcrumb;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
+import io.sentry.SentryTransaction;
 import io.sentry.protocol.User;
 
 public class MainActivity extends AppCompatActivity {
@@ -19,6 +20,9 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_main);
+
+        //   TODO - try before .onCreate
+        SentryTransaction activityTransaction = Sentry.startTransaction("MainActivity.onCreate");
 
         // SENTRY Tag and Breadcrumb
         String activity = this.getClass().getSimpleName();
@@ -91,6 +95,7 @@ public class MainActivity extends AppCompatActivity {
             NativeSample.message();
         });
 
+        activityTransaction.finish();
     }
 
 

--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -4,10 +4,12 @@ import android.app.Application;
 
 import java.util.List;
 
+//import io.sentry.Sentry;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryException;
 import io.sentry.protocol.User;
+import io.sentry.*;
 
 public class MyApplication extends Application {
     @Override
@@ -19,10 +21,6 @@ public class MyApplication extends Application {
 
             // This callback is used before the event is sent to Sentry.
             // You can modify the event or, when returning null, also discard the event.
-
-            // we now enable this in AndroidManifest.xml
-            // options.setEnableSessionTracking(true);
-
             options.setBeforeSend((event, hint) -> {
 
                 //Remove PII
@@ -41,7 +39,14 @@ public class MyApplication extends Application {
                 else
                     return event;
             });
+            options.setTracesSampleRate(1.0);
         });
+
+        SentryTransaction activityTransaction = Sentry.startTransaction("MainActivity.onCreate");
+        activityTransaction.finish();
+
+        // we now enable this in AndroidManifest.xml
+        // options.setEnableSessionTracking(true);
     }
 
 }

--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -42,8 +42,8 @@ public class MyApplication extends Application {
             options.setTracesSampleRate(1.0);
         });
 
-        SentryTransaction activityTransaction = Sentry.startTransaction("MainActivity.onCreate");
-        activityTransaction.finish();
+//        SentryTransaction activityTransaction = Sentry.startTransaction("MainActivity.onCreate");
+//        activityTransaction.finish();
 
         // we now enable this in AndroidManifest.xml
         // options.setEnableSessionTracking(true);


### PR DESCRIPTION
**Do Not Merge** this

for experimentation and feedback purposes only.

sdk.version `4.0.0-alpha.2`
sdk.name `sentry.java.android`

add lots of lifecycles/callbacks, ideas for spans:
https://developer.android.com/topic/libraries/architecture/lifecycle
child for onCreate onStart onDestroy
finish transaction on onPause onStop

activity lifecycles, view lifecycles, inflation, onClick callbacks.

## Based on
https://github.com/getsentry/sentry-java/pull/1058

## Testing
[MainActivity.onCreate Transaction](https://sentry.io/organizations/testorg-az/discover/paranoid-android:bda1287c25c84017aad6cbef7d85d2cd/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=261820&project=1801383&query=event.type%3Atransaction&sort=-timestamp&statsPeriod=14d&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1) (no inner spans set yet)