### PR TITLE
Attachments Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Additional documentation:
 
 | dependency    | version
 | ------------- |:-------------:|
-| sentry-android | 2.3.1 |
+| sentry-java | 4.0.0-beta.1 |
 | sentry-android-gradle-plugin | 1.7.35 |
 | Android Studio | 4.0.1 |
 | Gradle | 6.3 |
 | AVD | Nexus 5x API 29 x86, Pixel 2 API 29 |
 | sentry-cli | 1.55.1 |
-| macOS | Mojave 10.15.6 |
+| macOS | Catalina 10.15.7 |
 | java | 1.8.0_261 |
 | jdk | 1.8 |
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
-    implementation 'io.sentry:sentry-android:3.1.0'
+    implementation 'io.sentry:sentry-android:4.0.0-beta.1'
 }
 
 sentry {

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.text.format.Formatter;
+import android.view.View;
 import android.widget.Button;
 import androidx.appcompat.app.AppCompatActivity;
 import io.sentry.Breadcrumb;
@@ -61,36 +62,7 @@ public class MainActivity extends AppCompatActivity {
         // Handled - ArrayIndexOutOfBoundsException
         Button handled_exception_button = findViewById(R.id.handled_exception);
         handled_exception_button.setOnClickListener(view -> {
-            // Create a File and Add as attachment
-            File f = null;
-            try {
-                // creates temporary file
-                // f = File.createTempFile("tmp", ".txt", new File("C:/"));
-                Context c = view.getContext();
-                File cacheDirectory = c.getCacheDir();
-                f = File.createTempFile("tmp", ".txt", cacheDirectory);
-
-                Sentry.setTag("filePath", f.getAbsolutePath());
-
-                // prints absolute path
-                System.out.println("File path: "+f.getAbsolutePath());
-
-                // deletes file when the virtual machine terminate
-                f.deleteOnExit();
-
-                Attachment attachment = new Attachment(f.getAbsolutePath());
-
-                Sentry.configureScope(
-                        scope -> {
-                            scope.addAttachment(attachment);
-                        });
-
-            } catch(Exception e) {
-                // if any error occurs
-                Sentry.captureException(e);
-                e.printStackTrace();
-
-            }
+            addAttachment(view);
 
             Sentry.addBreadcrumb("Button for ArrayIndexOutOfBoundsException clicked..");
                 try {
@@ -125,6 +97,35 @@ public class MainActivity extends AppCompatActivity {
 
     }
 
+    private Boolean addAttachment(View view) {
+        // Create a File and Add as attachment
+        File f = null;
+        try {
+            Context c = view.getContext();
+            File cacheDirectory = c.getCacheDir();
+            f = File.createTempFile("tmp", ".txt", cacheDirectory);
+
+            Sentry.setTag("filePath", f.getAbsolutePath());
+
+            // prints absolute path
+            System.out.println("File path: "+f.getAbsolutePath());
+
+            // deletes file when the virtual machine terminate
+            f.deleteOnExit();
+
+            Attachment attachment = new Attachment(f.getAbsolutePath());
+
+            Sentry.configureScope(
+                    scope -> {
+                        scope.addAttachment(attachment);
+                    });
+
+        } catch(Exception e) {
+            Sentry.captureException(e);
+            e.printStackTrace();
+        }
+        return true;
+    }
 
     private String getIPAddress(){
 

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -10,6 +10,8 @@ import io.sentry.Breadcrumb;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.User;
+import io.sentry.Attachment;
+import java.io.File;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -35,6 +37,41 @@ public class MainActivity extends AppCompatActivity {
         User user = new User();
         user.setIpAddress(this.getIPAddress());
         Sentry.setUser(user);
+
+        // Create a File and Add as attachment
+        File f = null;
+
+        try {
+            // creates temporary file
+            f = File.createTempFile("tmp", ".txt", new File("C:/"));
+
+            // prints absolute path
+            System.out.println("File path: "+f.getAbsolutePath());
+
+            // deletes file when the virtual machine terminate
+            f.deleteOnExit();
+
+            // creates temporary file
+            f = File.createTempFile("tmp", null, new File("D:/"));
+
+            // prints absolute path
+            System.out.print("File path: "+f.getAbsolutePath());
+
+            // deletes file when the virtual machine terminate
+            f.deleteOnExit();
+
+            Attachment attachment = new Attachment(f.getAbsolutePath());
+
+            Sentry.configureScope(
+                    scope -> {
+                        scope.addAttachment(attachment);
+                    });
+
+        } catch(Exception e) {
+            // if any error occurs
+            e.printStackTrace();
+        }
+
 
 
         // Unhandled - ArithmeticException

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -38,44 +38,6 @@ public class MainActivity extends AppCompatActivity {
         user.setIpAddress(this.getIPAddress());
         Sentry.setUser(user);
 
-        // Create a File and Add as attachment
-        File f = null;
-
-        try {
-            // creates temporary file
-            f = File.createTempFile("tmp", ".txt", new File("C:/"));
-            Sentry.setTag("filePath", f.getAbsolutePath());
-            // prints absolute path
-            System.out.println("File path: "+f.getAbsolutePath());
-
-            // deletes file when the virtual machine terminate
-            f.deleteOnExit();
-
-            // creates temporary file
-            f = File.createTempFile("tmp", null, new File("D:/"));
-
-            // prints absolute path
-            System.out.print("File path: "+f.getAbsolutePath());
-
-            // deletes file when the virtual machine terminate
-            f.deleteOnExit();
-
-            Attachment attachment = new Attachment(f.getAbsolutePath());
-
-            Sentry.configureScope(
-                    scope -> {
-                        scope.addAttachment(attachment);
-                    });
-
-        } catch(Exception e) {
-            // if any error occurs
-            Sentry.captureException(e);
-            e.printStackTrace();
-
-        }
-
-
-
         // Unhandled - ArithmeticException
         Button div_by_zero_button = findViewById(R.id.div_zero);
         div_by_zero_button.setOnClickListener(view -> {
@@ -99,6 +61,46 @@ public class MainActivity extends AppCompatActivity {
         // Handled - ArrayIndexOutOfBoundsException
         Button handled_exception_button = findViewById(R.id.handled_exception);
         handled_exception_button.setOnClickListener(view -> {
+            // Create a File and Add as attachment
+            File f = null;
+            try {
+                // creates temporary file
+                // f = File.createTempFile("tmp", ".txt", new File("C:/"));
+                Context c = view.getContext();
+                File cacheDirectory = c.getCacheDir();
+                f = File.createTempFile("tmp", ".txt", cacheDirectory);
+
+                Sentry.setTag("filePath", f.getAbsolutePath());
+
+                // prints absolute path
+                System.out.println("File path: "+f.getAbsolutePath());
+
+                // deletes file when the virtual machine terminate
+                f.deleteOnExit();
+
+                // creates temporary file
+                f = File.createTempFile("tmp", null, new File("D:/"));
+
+                // prints absolute path
+                System.out.print("File path: "+f.getAbsolutePath());
+
+                // deletes file when the virtual machine terminate
+                f.deleteOnExit();
+
+                Attachment attachment = new Attachment(f.getAbsolutePath());
+
+                Sentry.configureScope(
+                        scope -> {
+                            scope.addAttachment(attachment);
+                        });
+
+            } catch(Exception e) {
+                // if any error occurs
+                Sentry.captureException(e);
+                e.printStackTrace();
+
+            }
+
             Sentry.addBreadcrumb("Button for ArrayIndexOutOfBoundsException clicked..");
                 try {
                     String[] strArr = new String[1];

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -78,15 +78,6 @@ public class MainActivity extends AppCompatActivity {
                 // deletes file when the virtual machine terminate
                 f.deleteOnExit();
 
-                // creates temporary file
-                f = File.createTempFile("tmp", null, new File("D:/"));
-
-                // prints absolute path
-                System.out.print("File path: "+f.getAbsolutePath());
-
-                // deletes file when the virtual machine terminate
-                f.deleteOnExit();
-
                 Attachment attachment = new Attachment(f.getAbsolutePath());
 
                 Sentry.configureScope(

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -69,7 +69,9 @@ public class MainActivity extends AppCompatActivity {
 
         } catch(Exception e) {
             // if any error occurs
+            Sentry.captureException(e);
             e.printStackTrace();
+
         }
 
 

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -44,7 +44,7 @@ public class MainActivity extends AppCompatActivity {
         try {
             // creates temporary file
             f = File.createTempFile("tmp", ".txt", new File("C:/"));
-
+            Sentry.setTag("filePath", f.getAbsolutePath());
             // prints absolute path
             System.out.println("File path: "+f.getAbsolutePath());
 

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -13,6 +13,9 @@ import io.sentry.SentryLevel;
 import io.sentry.protocol.User;
 import io.sentry.Attachment;
 import java.io.File;
+import java.io.FileOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -42,7 +45,7 @@ public class MainActivity extends AppCompatActivity {
         // Unhandled - ArithmeticException
         Button div_by_zero_button = findViewById(R.id.div_zero);
         div_by_zero_button.setOnClickListener(view -> {
-
+            addAttachment(view);
             Breadcrumb bc = new Breadcrumb();
             bc.setMessage("Button for ArithmeticException clicked...");
             bc.setLevel(SentryLevel.ERROR);
@@ -55,6 +58,7 @@ public class MainActivity extends AppCompatActivity {
         // Unhandled - NegativeArraySizeException
         Button negative_index_button = findViewById(R.id.negative_index);
         negative_index_button.setOnClickListener(view -> {
+            addAttachment(view);
             Sentry.addBreadcrumb("Button for NegativeArraySizeException clicked...");
             int[] a = new int[-5];
         });
@@ -92,6 +96,7 @@ public class MainActivity extends AppCompatActivity {
 
         // Native Message
         findViewById(R.id.native_message).setOnClickListener(view -> {
+            addAttachment(view);
             NativeSample.message();
         });
 
@@ -112,6 +117,10 @@ public class MainActivity extends AppCompatActivity {
 
             // deletes file when the virtual machine terminate
             f.deleteOnExit();
+
+            try (FileOutputStream fos = new FileOutputStream(f)) {
+                fos.write("test".getBytes(UTF_8));
+            }
 
             Attachment attachment = new Attachment(f.getAbsolutePath());
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -60,7 +60,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:text="Handled Java Error and Attachment"
+                android:text="Handled Java Error"
                 android:textColor="#4A3E56"
                 android:textSize="20sp"
                 android:textStyle="bold"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -60,7 +60,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:text="Handled Java Errors"
+                android:text="Handled Java Error and Attachment"
                 android:textColor="#4A3E56"
                 android:textSize="20sp"
                 android:textStyle="bold"


### PR DESCRIPTION
## Description
- [X] New Feature

To upload event attachments to an error. As of today 01/25/2021 the documentation says this is not available for crashes yet. I added the `addAttachment()` method to the following buttons:
- Unhandled Java Errors (both buttons)
- Handled Java Error
- Capture Message

The temp file is created, written to, and then disposed of when the AVD terminates.

Uses sentry-java `4.0.0 beta.1`

## Testing
See text file that got attached to this event
https://sentry.io/organizations/testorg-az/issues/1521554298/?project=1801383

![image](https://user-images.githubusercontent.com/8920574/105755945-f9850e80-5f19-11eb-974c-4d6e9a8a8955.png)


## Ideas | Documentation | Resources
https://stackoverflow.com/questions/17150597/file-createtempfile-vs-new-file

https://developer.android.com/reference/java/io/File

https://www.tutorialspoint.com/how-to-make-a-txt-file-in-internal-storage-in-android

https://stackoverflow.com/questions/1239026/how-to-create-a-file-in-android

https://www.tutorialspoint.com/java/io/file_createtempfile_directory.htm

https://developer.android.com/training/data-storage