### PR TITLE
Removed Classpath To Sentry Android Gradle Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Additional documentation:
 
 | dependency    | version
 | ------------- |:-------------:|
-| sentry-java | 4.1.0 |
-| sentry-android-gradle-plugin | 1.7.35 |
+| sentry-java | 5.1.2 |
+| sentry-android-gradle-plugin | 2.1.4 |
 | Android Studio | 4.0.1 |
-| Gradle | 6.3 |
+| Gradle | 6.5 |
 | AVD | Nexus 5x API 29 x86, Pixel 2 API 29 |
 | sentry-cli | 1.55.1 |
 | macOS | Catalina 10.15.7 |

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id "io.sentry.android.gradle"
+    id "io.sentry.android.gradle" version "2.1.4"
 }
 
 apply plugin: 'com.android.application'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.ydq.android.gradle.build.tool:nativeBundle:1.0.7'
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
         classpath 'com.fullstory:gradle-plugin-local:1.12.1'
     }
 }


### PR DESCRIPTION
Removed Classpath To Sentry Android Gradle Plugin In Build File Located In /android/build.gradle And Moved It To /android/app/build.gradle

https://docs.sentry.io/platforms/android/migration/