### PR TITLE
Checkout UI flow fix

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,7 +11,7 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
-
+-keep class com.example.vu.android.empowerplant.MainFragment$ItemDeliveryProcessException
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
 #-keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
-This demo utilizes ItemDeliveryProcessException to capture the checkout error.
-Because this is a custom exception, the classname was being obfuscated in release builds.
-BeforeSend in MyApplication contains logic for surfacing an error dialogue that depends on deobfuscated class names (ln 78)
-Solution:Updated proguard rules to exclude this exception class from obfuscation.

Expected UI after checkout error:
1. A dialogue "checking out" should appear briefly.
2. User feedback dialogue should appear & stay until acted upon by user