### PR TITLE
Update profiling method

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig = signingConfigs.debug // to be able to run release mode
             buildConfigField("String", "SE", "\"tda\"")

--- a/app/src/main/java/com/example/vu/android/MainActivity.java
+++ b/app/src/main/java/com/example/vu/android/MainActivity.java
@@ -31,7 +31,7 @@ public class MainActivity extends MyBaseActivity {
         // Unhandled - ArithmeticException
         Button div_by_zero_button = findViewById(R.id.div_zero);
         div_by_zero_button.setOnClickListener(view -> {
-            addAttachment();
+            addAttachment(false);
             Breadcrumb bc = new Breadcrumb();
             bc.setMessage("Button for ArithmeticException clicked...");
             bc.setLevel(SentryLevel.ERROR);
@@ -44,7 +44,7 @@ public class MainActivity extends MyBaseActivity {
         // Unhandled - NegativeArraySizeException
         Button negative_index_button = findViewById(R.id.negative_index);
         negative_index_button.setOnClickListener(view -> {
-            addAttachment();
+            addAttachment(false);
             Sentry.addBreadcrumb("Button for NegativeArraySizeException clicked...");
             int[] a = new int[-5];
         });
@@ -52,7 +52,7 @@ public class MainActivity extends MyBaseActivity {
         // Handled - ArrayIndexOutOfBoundsException
         Button handled_exception_button = findViewById(R.id.handled_exception);
         handled_exception_button.setOnClickListener(view -> {
-            addAttachment();
+            addAttachment(false);
 
             Sentry.addBreadcrumb("Button for ArrayIndexOutOfBoundsException clicked..");
                 try {

--- a/app/src/main/java/com/example/vu/android/MyBaseActivity.java
+++ b/app/src/main/java/com/example/vu/android/MyBaseActivity.java
@@ -65,7 +65,7 @@ public class MyBaseActivity extends AppCompatActivity  {
             mMyApp.setCurrentActivity( null ) ;
     }
 
-    protected Boolean addAttachment() {
+    protected Boolean addAttachment(Boolean secure) {
         File f = null;
         String fileName = "tmp" + UUID.randomUUID();
         boolean slowProfiling = BuildConfig.SLOW_PROFILING;
@@ -74,8 +74,8 @@ public class MyBaseActivity extends AppCompatActivity  {
             Context c = getApplicationContext();
             File cacheDirectory = c.getCacheDir();
 
-            if (slowProfiling) {
-                f = generateSlowProfile(cacheDirectory, fileName);
+            if (slowProfiling && secure) {
+                f = createTempFileSecure(cacheDirectory, fileName);
             } else {
                 f = File.createTempFile(fileName, ".txt", cacheDirectory);
             }
@@ -114,7 +114,7 @@ public class MyBaseActivity extends AppCompatActivity  {
         }
     }
 
-    protected File generateSlowProfile(File cacheDirectory, String fileName){
+    protected File createTempFileSecure(File cacheDirectory, String fileName){
         int maxTries = 1000000;
         boolean cacheFileExists = false;
         boolean outOfBounds = false;

--- a/app/src/main/java/com/example/vu/android/empowerplant/EmpowerPlantActivity.java
+++ b/app/src/main/java/com/example/vu/android/empowerplant/EmpowerPlantActivity.java
@@ -25,7 +25,7 @@ public class EmpowerPlantActivity extends MyBaseActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_empowerplant);
-        addAttachment();
+        addAttachment(true);
         this.loadFragmentList();
     }
 


### PR DESCRIPTION
## Type of Change


[x] Bugfix
[ ] New Feature
[ ] Enhancement
[ ] Refactoring

## Description

Fix automated tests and profiling data. 
The tests were failing because they were calling the `addAttachment` method that was modified on this [pull request](https://github.com/sentry-demos/android/pull/45). They were timing out....
So I added a boolean to only run the slow method at the beginning when it is being called from the `EmpowerPlantActivity.java` .
I also changed the name of the profiling method to reflect something closer to a real use-case.
Lastly, I changed the `minifyEnabled` attribute on the gradle to false, since I believe we need to see the names of the methods in the profile so we can demo to customers (In this case, when this is set to true, the `createTempFileSecure` method is minified). Below are the differences with this boolean set to true:

- `minifyEnabled` set to `true` - [link](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-android/caf81a7ebd0c4e1a882ae0d0cc971b0d/flamechart/?colorCoding=by+symbol+name&fov=0%2C5%2C13777283072%2C17&query=&sorting=call+order&tid=5418&view=top+down&xAxis=standalone)
- `minifyEnabled` set to `false` - [link](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-android/092d2c09f48f4b61bc928759d5c09d71/flamechart/?colorCoding=by+symbol+name&fov=0%2C3%2C14268552192%2C17&query=&sorting=call+order&tid=5369&view=top+down&xAxis=standalone) 

## Testing


`test_checkout_android`
- [saucelabs test](https://app.saucelabs.com/tests/30560952602540778c129dea78ad09a8)
- [sentry error](https://sentry.io/organizations/testorg-az/issues/3708455694/events/d778ef7947404de28a0883554637566b/?project=6749210)
- [profile](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-android/13fc85ef01db4cb58ad3811ac44c35e4/flamechart/?colorCoding=by+symbol+name&query=&sorting=call+order&tid=5507&view=top+down&xAxis=standalone)

`test_handlederror_android`
- [saucelabs test](https://app.saucelabs.com/tests/cc4b1a423b2848fd83174a28ac214038)
- [sentry error](https://sentry.io/organizations/testorg-az/issues/3745918269/events/9b7d1c42fb1d448e8c31306940a79843/?project=6749210)
- [profile](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-android/feb2dfb53e4b4a41977513138e99eb4a/flamechart/?colorCoding=by+symbol+name&query=&sorting=call+order&tid=5397&view=top+down&xAxis=standalone)

`test_nativemessage_android`
- [saucelabs test](https://app.saucelabs.com/tests/19ca2932149f4db5a2f81dbeb9664fa2)
- [sentry error](https://sentry.io/organizations/testorg-az/issues/3745924129/events/31d08d0be4df43cdaecc97f79306c7b7/?project=6749210)
- [profile](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-android/869b2330cde54ce08b6920f25395e997/flamechart/?colorCoding=by+symbol+name&query=&sorting=call+order&tid=5426&view=top+down&xAxis=standalone)

`test_unhandled_error`
- [saucelabs test](https://app.saucelabs.com/tests/e5156da636f94b87abb0f447970cef8c)
- [sentry error](https://sentry.io/organizations/testorg-az/issues/3745929429/events/551c021d3c8445bd910a28b986abd16b/?project=6749210)
- [profile](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-android/13fc85ef01db4cb58ad3811ac44c35e4/flamechart/?colorCoding=by+symbol+name&query=&sorting=call+order&tid=5507&view=top+down&xAxis=standalone)

`test_unhandled_error2`
- [saucelabs test](https://app.saucelabs.com/tests/2d0b970c751e430fb88f4f7d8e21a93c)
- [sentry error](https://sentry.io/organizations/testorg-az/issues/3745944202/events/02ec7daecbbf43c4a934bbc9fe2801ce/?project=6749210)
- [profile](https://sentry.io/organizations/testorg-az/profiling/profile/sergio-android/fcbaa91e49b945598e4505f5c491ddd7/flamechart/?colorCoding=by+symbol+name&fov=0%2C6%2C13613599744%2C17&query=&sorting=call+order&tid=5430&view=top+down&xAxis=standalone)

This is a discover [query](https://sentry.io/organizations/testorg-az/discover/homepage/?display=top5&end=2022-11-17T23%3A59%3A59.000&field=issue&field=title&field=se&field=count%28%29&name=All+Events&project=6749210&query=&sort=-title&start=2022-11-17T06%3A10%3A00.000&yAxis=count%28%29) for all the tests captured on `sergio-android` with the new apk file
This is a discover [query](https://sentry.io/organizations/testorg-az/discover/homepage/?display=top5&field=issue&field=title&field=count%28%29&name=All+Events&project=1801383&query=%21se%3Areplay&sort=-title&statsPeriod=24h&yAxis=count%28%29) for all the tests that are currently being captured using `TDA` for the `android` project

This the performance [data](https://sentry.io/organizations/testorg-az/discover/homepage/?end=2022-11-17T23%3A59%3A59&field=title&field=event.type&field=se&field=count%28%29&name=All+Events&project=6749210&query=event.type%3Atransaction&sort=-title&start=2022-11-16T00%3A00%3A00&utc=true&yAxis=count%28%29) for `sergio-android`

This is the [link](https://github.com/sergiosentry/demo-test/blob/main/app-release.apk) to the `app-release.apk` file I ran the tests against.....This file would eventually be uploaded with the next release