### PR TITLE
Added Gson to proguard exclusion

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class com.google.gson.Gson { *; }

--- a/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
+++ b/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
@@ -232,15 +232,22 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
     }
 
     private void processProducts() {
-        for (StoreItem empowerStoreItem : empowerStoreItems) {
-            empowerStoreItem.isValid();
-            empowerStoreItem.isValid();
-        }
+        getIterator(42);
         try {
             Thread.sleep(50);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private int getIterator(int n) {
+        if (n <= 0) {
+            return 0;
+        }
+        if (n == 1 || n == 2) {
+            return 1;
+        }
+        return getIterator(n-1) + getIterator(n-2);
     }
 
     private String getEmpowerPlantDomain() {


### PR DESCRIPTION
added Gson to proguard exclusion

Relates to https://github.com/sentry-demos/android/issues/70

not sure if it's worth doing it, as the user is probably not going to exclude `Gson` from obfuscation, even if it would work for the demo purpose.
Let's wait for the backend to publish the updates related to [function names in profiles](https://github.com/getsentry/rust-proguard/pull/30)