### PR TITLE
Add Gson to proguard exclusion

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class com.google.gson.Gson { *; }


### PR DESCRIPTION
added Gson to proguard exclusion

Relates to https://github.com/sentry-demos/android/issues/70

not sure if it's worth doing it, as the user is probably not going to exclude Gson from obfuscation, even if it would work for the demo purpose.
Let's wait for the backend to publish the updates related to https://github.com/getsentry/rust-proguard/pull/30