### PR TITLE
Make app start profiling work in tests

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -91,6 +91,12 @@
             android:authorities="${applicationId}.thirdpartycontentprovider"
             android:name=".ThirdPartyContentProvider" />
 
+        <provider
+            android:exported="false"
+            android:authorities="${applicationId}.initcontentprovider"
+            android:initOrder="9999"
+            android:name=".InitContentProvider" />
+
 
     </application>
 

--- a/app/src/main/java/com/example/vu/android/InitContentProvider.java
+++ b/app/src/main/java/com/example/vu/android/InitContentProvider.java
@@ -1,0 +1,105 @@
+package com.example.vu.android;
+
+import static io.sentry.Sentry.APP_START_PROFILING_CONFIG_FILE_NAME;
+
+import android.annotation.SuppressLint;
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+import io.sentry.SentryAppStartProfilingOptions;
+import io.sentry.SentryOptions;
+
+public class InitContentProvider extends ContentProvider {
+
+    @Override
+    public boolean onCreate() {
+
+        final Context context = getContext();
+        if (context == null) {
+            return true;
+        }
+
+        final @NotNull SentryOptions options = createOptions(context);
+        final @NotNull SentryAppStartProfilingOptions appStartProfilingOptions = createAppStartOptions(options);
+        // Manually create all folders required by the SDK to work
+        final @NotNull File cacheDir = new File(context.getCacheDir(), "sentry");
+        final @NotNull File configFile = new File(cacheDir, APP_START_PROFILING_CONFIG_FILE_NAME);
+        cacheDir.mkdirs();
+        new File(options.getProfilingTracesDirPath()).mkdirs();
+
+        // Write option to config file to make the SDK think it was already initialized.
+        try (final OutputStream outputStream = new FileOutputStream(configFile);
+             final Writer writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
+            options.getSerializer().serialize(appStartProfilingOptions, writer);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    @SuppressLint("VisibleForTests")
+    private SentryOptions createOptions(final @NotNull Context context) {
+        SentryOptions options = new SentryOptions();
+        options.setDsn("https://3d2ac63d6e1a4c6e9214443678f119a3@o87286.ingest.sentry.io/1801383");
+        options.setCacheDirPath(new File(context.getCacheDir(), "sentry").getAbsolutePath());
+        return options;
+    }
+
+    @SuppressLint("VisibleForTests")
+    private SentryAppStartProfilingOptions createAppStartOptions(SentryOptions options) {
+        SentryAppStartProfilingOptions appStartProfilingOptions = new SentryAppStartProfilingOptions();
+        appStartProfilingOptions.setProfileSampled(true);
+        appStartProfilingOptions.setTraceSampled(true);
+        appStartProfilingOptions.setProfileSampleRate(1.0);
+        appStartProfilingOptions.setTraceSampleRate(1.0);
+        appStartProfilingOptions.setProfilingTracesDirPath(options.getProfilingTracesDirPath());
+        appStartProfilingOptions.setProfilingEnabled(true);
+        appStartProfilingOptions.setProfilingTracesHz(options.getProfilingTracesHz());
+        return appStartProfilingOptions;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+}


### PR DESCRIPTION
added a new content provider that writes app start profiling options to a config file to make the SDK think it was already initialized.
This way app start profiling will work the first time the app is started, too, like in tests.
Fixes https://github.com/sentry-demos/android/issues/134