### PR TITLE
Add Custom Metrics

### DIFF
--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -72,6 +72,7 @@ public class MyApplication extends Application {
             options.setAttachThreads(true);
             options.setEnableAppStartProfiling(true);
             options.setEnablePerformanceV2(true);
+            options.setEnableMetrics(true);
             options.setBeforeSend((event, hint) -> {
 
                 //Remove PII


### PR DESCRIPTION
# Description

Add custom metrics to the Android demo app. These replicate the same metrics that were added to our react service [here](https://github.com/sentry-demos/empower/pull/376)

- `products_request.duration`
- `checkout.click`
- `checkout.error`
- `checkout.success`


