### PR TITLE
forcing /checkout to fail via `validate_inventory: "true"`

### DIFF
--- a/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
+++ b/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
@@ -396,6 +396,7 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
             cart.put("quantities", quantities);
             postBody.put("cart", cart);
             postBody.put("form", new JSONObject());// This line currently mocks non existent form data
+            postBody.put("validate_inventory", "true");
 
         } catch (JSONException e) {
             ISpan span = Sentry.getSpan();


### PR DESCRIPTION
flask's /checkout does not error out unless you now pass it `validate_inventory: "true"` in the body

This change was made a few days ago via https://github.com/sentry-demos/empower/pull/573

for some reason /checkout transaction was not being sent in the success case 🤷 
regardless, adding `validate_inventory: "true"` gets us back to a working state in terms of error and transaction (see below)

![image](https://github.com/user-attachments/assets/901dd8fa-f7f8-42be-811a-b553f5a0f3d0)
