### PR TITLE
Release weekly automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,17 @@
 name: Release
 on:
   workflow_dispatch:
+    inputs:
+      version_name:
+        description: 'The version name to release. E.g. 24.12.31'
+        required: true
+        default: null
+      version_code:
+        description: 'The version code (numeric) to release. E.g. 241231'
+        required: true
+        default: null
+  schedule:
+    - cron: "0 0 * * 0" # Runs every Sunday at midnight
 
 jobs:
   empower-plant-release:
@@ -16,8 +27,26 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Run Deploy Script
-        run: ./deploy_project.sh
+      - name: Setup Automatic Version Name And Code
+        if: inputs.version_name == null
+        run: |
+          echo "VERSION_NAME=$(date +'%y.%m.%d')" >> $GITHUB_ENV
+          echo "VERSION_CODE=$(date +'%y%m%d')" >> $GITHUB_ENV
+        shell: sh
+
+      - name: Run Deploy Script (manual version)
+        if: inputs.version_name != null
+        run: ./deploy_project.sh ${{ inputs.version_name }}
+        shell: sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VERSION_NAME: ${{ inputs.version_name }}
+          VERSION_CODE: ${{ inputs.version_code }}
+
+      - name: Run Deploy Script (automatic version)
+        if: inputs.version_name == null
+        run: ./deploy_project.sh "$(date +'%y.%m.%d')"
         shell: sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         required: true
         default: null
   schedule:
-    - cron: "0 0 * * 0" # Runs every Sunday at midnight
+    - cron: "0 0 1,8,15,22 * *" # 1st, 8th, 15th, and 22nd of the month
 
 jobs:
   empower-plant-release:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,8 +38,8 @@ android {
         applicationId "com.example.vu.android"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 48
-        versionName "2.11.3"
+        versionCode System.getenv('VERSION_CODE')?.toInteger() ?: 48
+        versionName System.getenv('VERSION_NAME') ?: "2.11.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {

--- a/deploy_project.sh
+++ b/deploy_project.sh
@@ -9,8 +9,12 @@ if ! command -v gh &> /dev/null; then
   error_exit "gh is not installed, make sure you run 'make init' (see README.md)."
 fi
 
+# When this script is called from release workflow, the version is passed as an argument, otherwise it will be read from the app/build.gradle file
+PACKAGE_VERSION=$1
+if [ -z "$1" ]; then
+  PACKAGE_VERSION=$(grep 'versionName' app/build.gradle | awk -F\" {'print $2'})
+fi
 PACKAGE_NAME=$(grep 'applicationId' app/build.gradle | awk -F\" {'print $2'})
-PACKAGE_VERSION=$(grep 'versionName' app/build.gradle | awk -F\" {'print $2'})
 REPO=sentry-demos/android
 
 # Check if current version was already released


### PR DESCRIPTION
gradle build now reads version name and code from environment variables, if present
release workflow now runs weekly, other than manually

Closes https://github.com/sentry-demos/android/issues/145