### PR TITLE
More flexible release upload with deploy_project.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run Deploy Script (automatic version)
         if: inputs.version_name == null
-        run: ./deploy_project.sh "$(date +'%y.%m.%d')"
+        run: ./deploy_project.sh "$(date +'%y.%m.%d')" release app-release.apk
         shell: sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is preparation for generalizing this logic and merging this and all other mobile repos into the `empower` monorepo where we will have a fully automated CI. 

Changes:
- parametrize `deploy_project.sh` with build type (release/debug) and output file name (name under which build artifact will be uploaded to GH)
- if release already exists upload files to it, replacing if a file already exists
- do not mark new releases as "Latest" (will be reserved for `master` only so it shows up at the top)
- don't build both release and debug, just one


Idea is to have the just 1 latest release, likely named after the `master/main` branch with artifacts filenames following `<project>_[<os>]_[debug|release].<ext>` format, e.g:

```
Release name: master
Tag: master
Timestamp: May 28, 2025
Latest: yes
Artifacts:
- android_release.apk
- ios_release.zip
- react-native_android_release.apk
- react-native_ios_release.zip
- flutter_android_release.apk

Release name: my-pr-branch
Tag: my-pr-branch
Timestamp: Jun 12, 2025
Latest: no
Artifacts:
- ios_release.zip
```

This will simplify things a lot. Semver releases will still be created in Sentry and baked into application bundles, we just won't be creating GitHub releases for each one.

# Testing 
ran `deploy_project.sh` locally