### PR TITLE
Enable Sentry Size Analysis (and bump gradle plugin to 6.6.0)

### DIFF
--- a/.github/workflows/sentry-size-analysis.yml
+++ b/.github/workflows/sentry-size-analysis.yml
@@ -1,0 +1,28 @@
+name: Sentry Size Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  size-analysis:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build release bundle (uploads to Sentry Size Analysis)
+        run: ./gradlew :app:bundleRelease
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.1.0"
+    id "io.sentry.android.gradle" version "6.6.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -147,6 +147,9 @@ sentry {
     debug = true
     includeSourceContext = true
     additionalSourceDirsForSourceContext = ["src/main/java"]
+    sizeAnalysis {
+        enabled = providers.environmentVariable("GITHUB_ACTIONS").present
+    }
     tracingInstrumentation {
         enabled = true
         logcat {


### PR DESCRIPTION
## Summary
- Enable Sentry Size Analysis by adding a `sizeAnalysis { enabled = ... }` block, gated on `GITHUB_ACTIONS` so APK/bundle uploads only run from CI.
- Bump `io.sentry.android.gradle` from 6.1.0 → 6.6.0 (minimum version that supports the `sizeAnalysis` DSL).
- Bundles the prior plugin upgrade commits from `upgrade/sentry-gradle-plugin-6.1.0` (5.9.0 → 6.1.0, Gradle → 8.14.2, refreshed APKs).

Per https://docs.sentry.io/product/size-analysis/ and the Android platform guide.

## Test plan
- [ ] `./gradlew help` configures cleanly
- [ ] With `GITHUB_ACTIONS=true`, `uploadSentryApkRelease` / `uploadSentryBundleRelease` tasks are registered
- [ ] CI builds with `SENTRY_AUTH_TOKEN` set upload to Sentry Size Analysis
- [ ] Confirm size analysis report appears in Sentry under the `demo` org / `android` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)