### PR TITLE
Bump Sentry Gradle plugin 6.10.0 → 6.11.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.10.0"
+    id "io.sentry.android.gradle" version "6.11.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'


### PR DESCRIPTION
## Summary

Bumps the Sentry Android Gradle Plugin from **6.10.0 → 6.11.0**, which brings the bundled SDK from **8.43.1 → 8.43.2**. The `sentry-native-ndk` remains at **0.14.2** (SDK 8.43.2 does not bump native).

## Version Changes

| Component | Old | New |
|-----------|-----|-----|
| Sentry Android Gradle Plugin | 6.10.0 | 6.11.0 |
| Sentry Android SDK (auto-installed) | 8.43.1 | 8.43.2 |
| sentry-native-ndk | 0.14.2 | 0.14.2 (unchanged) |

## Changelogs

- [Gradle plugin 6.11.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6110)
- [SDK 8.43.2](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8432)

## What's in the bump

**Plugin 6.11.0 fixes:**
- Resolve sentry-cli path as a task input instead of memoizing in a static field (fixes stale-path build failures when switching branches with config cache)
- Defer telemetry default-org lookup to execution time (config cache no longer re-runs sentry-cli on every build)
- Published POMs no longer declare transitive `kotlin-stdlib` dependency
- Normalize Linux ARM64 architecture name for bundled sentry-cli binary lookup

**SDK 8.43.2 improvements:**
- DSN parsing performance improvement (custom string parsing replaces `java.net.URI`)
- Removes unnecessary boxing for better performance
- Session Replay: fixes `VerifyError` in Compose masking with DexGuard/R8 obfuscation
- Session Replay: fixes Compose view masking issues in obfuscated/minified builds

## New features implemented

None — this release contains only bug fixes and performance improvements. No new SDK features to demonstrate.

## Features skipped

None — there were no new features in the changelog between 6.10.0 and 6.11.0.

## Build verification

Build could not be verified in the CI environment due to network restrictions (403 from Google Maven). The change is a single version number bump in `app/build.gradle` with no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvHLCM2LsSzNUQndxHuxUz)_