### PR TITLE
Bump Sentry Gradle plugin 6.10.0 → 6.12.0, SDK → 8.44.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.10.0"
+    id "io.sentry.android.gradle" version "6.12.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.14.2'
+    implementation 'io.sentry:sentry-native-ndk:0.15.1'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -141,6 +141,9 @@ tasks.withType(Test) {
 }
 
 sentry {
+    autoInstallation {
+        sentryVersion.set("8.44.1")
+    }
     autoUpload = true
     uploadNativeSymbols = true
     includeNativeSources = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,9 @@
         <meta-data
             android:name="io.sentry.metrics.enabled"
             android:value="true" />
+        <meta-data
+            android:name="io.sentry.standalone-app-start-tracing.enable"
+            android:value="true" />
 
         <provider
             android:exported="false"


### PR DESCRIPTION
## Summary

Bumps the Sentry Android Gradle Plugin from **6.10.0 → 6.12.0**, pins the SDK to **8.44.1**, and bumps `sentry-native-ndk` from **0.14.2 → 0.15.1**.

Supersedes #225 (which only covered 6.10.0 → 6.11.0 with no new features).

## Version Changes

| Component | Old | New |
|-----------|-----|-----|
| Sentry Android Gradle Plugin | 6.10.0 | 6.12.0 |
| Sentry Android SDK (auto-installed) | 8.43.1 | 8.44.1 (pinned via `autoInstallation`) |
| sentry-native-ndk | 0.14.2 | 0.15.1 |

## Changelogs

- [Gradle plugin 6.12.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6120)
- [Gradle plugin 6.11.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6110)
- [SDK 8.44.1](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8441)
- [SDK 8.44.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8440)
- [SDK 8.43.2](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8432)
- [sentry-native 0.15.1](https://github.com/getsentry/sentry-native/releases/tag/0.15.1)
- [sentry-native 0.15.0](https://github.com/getsentry/sentry-native/releases/tag/0.15.0)

## What's in the bump

**Plugin 6.12.0:**
- CLI bumped from v3.5.0 to v3.5.1

**Plugin 6.11.0 fixes:**
- Resolve sentry-cli path as a task input (fixes stale-path build failures with config cache)
- Defer telemetry default-org lookup to execution time (config cache improvement)
- Published POMs no longer declare transitive `kotlin-stdlib` dependency
- Normalize Linux ARM64 architecture name for bundled sentry-cli binary lookup

**SDK 8.44.0 features:**
- `enableStandaloneAppStartTracing` option — sends app start as standalone transaction with measurements and phase spans
- On Android 15+ (API 35), reports why OS started process via `app.vitals.start.reason`

**SDK 8.44.1 fixes:**
- Fix `FirstDrawDoneListener` leaking an `OnGlobalLayoutListener` per registration

**SDK 8.43.2 improvements:**
- DSN parsing performance improvement (custom string parsing replaces `java.net.URI`)
- Session Replay: fixes for Compose masking under DexGuard/R8 obfuscation

**sentry-native 0.15.0:**
- Opt-in async crash upload mode
- Linux symbolication of stack frames in crash daemon
- macOS: thread names in crash reports
- Increased `SENTRY_CRASH_MAX_MODULES` from 512 to 2048

**sentry-native 0.15.1:**
- Fix partial disk writes when streaming envelopes
- Android breadcrumb `data` sent as structured object instead of raw JSON string

## New features implemented

1. **Standalone App Start Tracing** — Enabled via `io.sentry.standalone-app-start-tracing.enable` manifest entry. The SDK will now emit a dedicated \"App Start\" transaction (op: `app.start`) with app start measurements and phase spans (`process.load`, `contentprovider.load`, `application.load`, activity lifecycle), sharing the same `traceId` as the first activity transaction for trace linking.

2. **SDK pinned to 8.44.1** — Added `autoInstallation { sentryVersion.set(\"8.44.1\") }` in the `sentry {}` block to ensure the latest SDK with bugfixes is used, rather than the plugin's bundled 8.44.0.

## Features already covered in the codebase

- **Feature Flags API** (`Sentry.addFeatureFlag`) — already demonstrated in `MyApplication.java` with `enable-dark-mode` and `new-checkout-flow` flags
- **Scope Attributes API** (`Sentry.setAttribute`) — already demonstrated in `MyApplication.java` with `customer.plan` and `customer.email`
- **Metrics API** — already enabled via `io.sentry.metrics.enabled=true` manifest entry

## Features skipped

1. **`SentrySQLiteDriver`** (SDK 8.44.1, experimental) — Requires `androidx.sqlite:sqlite` 2.5.0+ with the new `SQLiteDriver` interface. The app uses Room 2.6.1 which uses the legacy `SupportSQLiteOpenHelper` API; upgrading to Room 2.7+ would be required, and the project has an explicit warning against Room upgrades due to Saucelabs test compatibility.

2. **sentry-native opt-in async crash upload** (native 0.15.0) — This is a native C API feature (`sentry_options_set_async_crash_upload`) not exposed through the Android Java SDK.

## Build verification

Build could not be fully verified in the CI environment due to network restrictions (403 from Google Maven). The Gradle configuration phase started successfully (Gradle wrapper resolved, daemon started) but could not download the Android Gradle Plugin artifact. The changes are version bumps and a manifest entry addition — structurally straightforward.

## Files changed

- `app/build.gradle` — Plugin 6.10.0→6.12.0, sentry-native-ndk 0.14.2→0.15.1, added `autoInstallation` block
- `app/src/main/AndroidManifest.xml` — Added `io.sentry.standalone-app-start-tracing.enable` meta-data entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnrhDzkYTHjJRwXkcMpVPv)_