### PR TITLE
Bump Sentry Gradle plugin 6.10.0 → 6.13.0, SDK → 8.46.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.10.0"
+    id "io.sentry.android.gradle" version "6.13.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.14.2'
+    implementation 'io.sentry:sentry-native-ndk:0.15.2'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -141,6 +141,9 @@ tasks.withType(Test) {
 }
 
 sentry {
+    autoInstallation {
+        sentryVersion.set("8.46.0")
+    }
     autoUpload = true
     uploadNativeSymbols = true
     includeNativeSources = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,9 @@
         <meta-data
             android:name="io.sentry.metrics.enabled"
             android:value="true" />
+        <meta-data
+            android:name="io.sentry.standalone-app-start-tracing.enable"
+            android:value="true" />
 
         <provider
             android:exported="false"


### PR DESCRIPTION
## Summary

Bumps the Sentry Android Gradle Plugin from **6.10.0 → 6.13.0**, pins the SDK to **8.46.0**, and bumps `sentry-native-ndk` from **0.14.2 → 0.15.2**.

Supersedes #227 (which covered 6.10.0 → 6.12.0 / SDK 8.44.1).

## Version Changes

| Component | Old | New |
|-----------|-----|-----|
| Sentry Android Gradle Plugin | 6.10.0 | 6.13.0 |
| Sentry Android SDK (auto-installed) | ~8.43.1 | 8.46.0 (pinned via `autoInstallation`) |
| sentry-native-ndk | 0.14.2 | 0.15.2 |

## Changelogs

- [Gradle plugin 6.13.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6130)
- [Gradle plugin 6.12.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6120)
- [Gradle plugin 6.11.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6110)
- [SDK 8.46.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8460)
- [SDK 8.45.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8450)
- [SDK 8.44.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8440)
- [SDK 8.44.1](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8441)
- [SDK 8.43.2](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8432)
- [sentry-native 0.15.2](https://github.com/getsentry/sentry-native/releases/tag/0.15.2)
- [sentry-native 0.15.1](https://github.com/getsentry/sentry-native/releases/tag/0.15.1)
- [sentry-native 0.15.0](https://github.com/getsentry/sentry-native/releases/tag/0.15.0)

## What's in the bump

**Plugin 6.13.0:**
- Auto-instrument `SQLiteDriver` for Room users — wraps `SupportSQLiteOpenHelper` automatically when `tracingInstrumentation.DATABASE` is enabled (it is in this project). This means Room database queries now get automatic tracing spans with zero code changes.
- Build dependency pinning with Gradle dependency locking and SHA-256 verification (security hardening)

**Plugin 6.12.0:**
- CLI bumped from v3.5.0 to v3.5.1

**Plugin 6.11.0 fixes:**
- Resolve sentry-cli path as a task input (fixes stale-path build failures with config cache)
- Defer telemetry default-org lookup to execution time (config cache improvement)
- Published POMs no longer declare transitive `kotlin-stdlib` dependency
- Normalize Linux ARM64 architecture name for bundled sentry-cli binary lookup

**SDK 8.46.0:**
- Major performance improvements: reduced writer buffer sizes, optimized JSON serialization, reduced breadcrumb allocation overhead, faster timestamp parsing, reduced Android startup overhead
- Behavioral change: collections from scope getters are now shared state (reduced overhead)
- Fix: Session Replay network detail response body size for gzip-compressed responses

**SDK 8.45.0:**
- On Android 15+ (API 35), the standalone `app.start` transaction now reports OS process startup reason via `app.vitals.start.reason` trace data (e.g. launcher, broadcast, service, content_provider)
- Bundled native SDK bumped to 0.15.2

**SDK 8.44.0:**
- `enableStandaloneAppStartTracing` option — sends app start as a standalone transaction with measurements and phase spans (`process.load`, `contentprovider.load`, `application.load`, activity lifecycle)

**SDK 8.44.1:**
- Fix `FirstDrawDoneListener` leaking an `OnGlobalLayoutListener` per registration

**SDK 8.43.2:**
- DSN parsing performance improvement (custom string parsing replaces `java.net.URI`)
- Session Replay fixes for Compose masking under DexGuard/R8 obfuscation

**sentry-native 0.15.2:**
- Fix symbol name resolution for crashes in multi-module apps
- In-process app-hang detection via background heartbeat thread

**sentry-native 0.15.1:**
- Fix partial disk writes when streaming envelopes
- Android breadcrumb `data` sent as structured object instead of raw JSON string

**sentry-native 0.15.0:**
- Opt-in async crash upload mode
- Linux symbolication of stack frames in crash daemon
- Increased `SENTRY_CRASH_MAX_MODULES` from 512 to 2048

## New features implemented

1. **Standalone App Start Tracing** (SDK 8.44.0) — Enabled via `io.sentry.standalone-app-start-tracing.enable` manifest entry. The SDK emits a dedicated "App Start" transaction (op: `app.start`) with app start measurements and phase spans, sharing the same `traceId` as the first activity transaction for trace linking. On Android 15+ (SDK 8.45.0), this also reports the OS process startup reason.

2. **Auto SQLiteDriver Instrumentation** (Plugin 6.13.0) — Automatic via the plugin's `tracingInstrumentation` feature (already enabled). Room database queries now get tracing spans without code changes.

3. **SDK pinned to 8.46.0** — Added `autoInstallation { sentryVersion.set("8.46.0") }` in the `sentry {}` block to pick up the latest performance improvements and fixes beyond what the plugin bundles (8.45.0).

## Features already covered in the codebase

- **Feature Flags API** (`Sentry.addFeatureFlag`) — already demonstrated in `MyApplication.java` with `enable-dark-mode` and `new-checkout-flow` flags
- **Scope Attributes API** (`Sentry.setAttribute`) — already demonstrated across multiple files: `MyApplication.java` (customer.plan, customer.email), `MainFragment.java` (screen, checkout.cart_size, checkout.step), `StoreItemDetailActivity.kt` (screen, item.sku), `EmpowerPlantActivity.java` (screen)
- **Metrics API** (`Sentry.metrics()`) — already demonstrated: counters for `app.launched`, `product.viewed`, `checkout.attempted`; distribution for `checkout.cart_size`; manifest flag `io.sentry.metrics.enabled=true` already set
- **User Feedback** (`Sentry.feedback()`) — already demonstrated in `MyApplication.java` with shake gesture enabled
- **Tombstones** — already enabled via `io.sentry.tombstone.enable` and `io.sentry.tombstone.attach-raw` manifest entries
- **ANR profiling** — already enabled via `io.sentry.anr.profiling.sample-rate` manifest entry
- **Historical ANR reporting** — already enabled via `io.sentry.anr.report-historical` manifest entry
- **Logs API** — already enabled in `MyApplication.java` via `options.getLogs().setEnabled(true)`

## Features skipped

1. **`SentrySQLiteDriver`** (SDK 8.44.1, experimental) — Requires `androidx.sqlite:sqlite` 2.5.0+ with the new `SQLiteDriver` interface. The app uses Room 2.6.1 which uses the legacy `SupportSQLiteOpenHelper` API; upgrading to Room 2.7+ would be required, and the project has an explicit warning against Room upgrades due to Saucelabs test compatibility. Note: the plugin 6.13.0 auto-instrumentation for `SupportSQLiteOpenHelper` (the legacy API) works automatically without a Room upgrade.

2. **sentry-native opt-in async crash upload** (native 0.15.0) — This is a native C API feature (`sentry_options_set_async_crash_upload`) not exposed through the Android Java SDK.

3. **`ReplayFrameObserver`** (SDK 8.43.0) — This is a development/debugging API for observing captured replay frames (bitmaps), not a user-facing feature. Session Replay is already fully configured in the app.

## Build verification

Build could not be fully verified in the CI environment due to network restrictions (403 from Google Maven). The Gradle wrapper resolved and daemon started successfully, confirming the configuration phase begins correctly. The changes are version bumps, a manifest entry addition, and an `autoInstallation` block — structurally straightforward.

## Files changed

- `app/build.gradle` — Plugin 6.10.0→6.13.0, sentry-native-ndk 0.14.2→0.15.2, added `autoInstallation` block pinning SDK to 8.46.0
- `app/src/main/AndroidManifest.xml` — Added `io.sentry.standalone-app-start-tracing.enable` meta-data entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiQ5AvwKxuRUUZgiZ7Ks6E)_