### PR TITLE
Bump Sentry Gradle plugin 6.10.0 → 6.15.0, SDK → 8.49.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.14.0"
+    id "io.sentry.android.gradle" version "6.15.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -142,7 +142,7 @@ tasks.withType(Test) {
 
 sentry {
     autoInstallation {
-        sentryVersion.set("8.48.0")
+        sentryVersion.set("8.49.0")
     }
     autoUpload = true
     uploadNativeSymbols = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,7 +142,7 @@ tasks.withType(Test) {
 
 sentry {
     autoInstallation {
-        sentryVersion.set("8.47.0")
+        sentryVersion.set("8.48.0")
     }
     autoUpload = true
     uploadNativeSymbols = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.10.0"
+    id "io.sentry.android.gradle" version "6.14.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.14.2'
+    implementation 'io.sentry:sentry-native-ndk:0.15.3'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -141,6 +141,9 @@ tasks.withType(Test) {
 }
 
 sentry {
+    autoInstallation {
+        sentryVersion.set("8.47.0")
+    }
     autoUpload = true
     uploadNativeSymbols = true
     includeNativeSources = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -111,6 +111,9 @@
         <meta-data
             android:name="io.sentry.standalone-app-start-tracing.enable"
             android:value="true" />
+        <meta-data
+            android:name="io.sentry.tombstone.report-historical"
+            android:value="true" />
 
         <provider
             android:exported="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,6 +108,9 @@
         <meta-data
             android:name="io.sentry.metrics.enabled"
             android:value="true" />
+        <meta-data
+            android:name="io.sentry.standalone-app-start-tracing.enable"
+            android:value="true" />
 
         <provider
             android:exported="false"

--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -11,6 +11,7 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Toast;
 import io.sentry.Hint;
+import io.sentry.ISpan;
 import io.sentry.SamplingContext;
 import io.sentry.SentryOptions;
 import io.sentry.SentryReplayEvent;
@@ -140,6 +141,13 @@ public class MyApplication extends Application {
             });
         });
 
+        Sentry.extendAppStart();
+        ISpan appStartSpan = Sentry.getExtendedAppStartSpan();
+        ISpan initChild = null;
+        if (appStartSpan != null) {
+            initChild = appStartSpan.startChild("app.init", "Post-init setup");
+        }
+
         String[] allCustomerTypes = {"medium-plan", "large-plan", "small-plan", "enterprise"};
         String customerType = allCustomerTypes[(int) (Math.random() * 4)];
         Sentry.setTag("customerType", customerType);
@@ -165,6 +173,11 @@ public class MyApplication extends Application {
         boolean darkMode = Math.random() > 0.5;
         Sentry.addFeatureFlag("enable-dark-mode", darkMode);
         Sentry.addFeatureFlag("new-checkout-flow", "enterprise".equals(customerType));
+
+        if (initChild != null) {
+            initChild.finish();
+        }
+        Sentry.finishExtendedAppStart();
     }
 
     private void launchUserFeedback(SentryId sentryId) {

--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -20,13 +20,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.sentry.Sentry;
-import io.sentry.SentryAttribute;
-import io.sentry.SentryAttributes;
 import io.sentry.UserFeedback;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.SentryLevel;
-import io.sentry.SentryLogLevel;
-import io.sentry.logger.SentryLogParameters;
 import io.sentry.protocol.Feedback;
 import io.sentry.protocol.SentryException;
 import io.sentry.protocol.SentryId;
@@ -169,16 +165,6 @@ public class MyApplication extends Application {
         boolean darkMode = Math.random() > 0.5;
         Sentry.addFeatureFlag("enable-dark-mode", darkMode);
         Sentry.addFeatureFlag("new-checkout-flow", "enterprise".equals(customerType));
-
-        Sentry.logger().log(
-            SentryLogLevel.INFO,
-            SentryLogParameters.create(SentryAttributes.of(
-                SentryAttribute.named("customer.plan", customerType),
-                SentryAttribute.named("customer.email", email),
-                SentryAttribute.named("dark_mode", darkMode)
-            )),
-            "App initialized for %s customer", customerType
-        );
     }
 
     private void launchUserFeedback(SentryId sentryId) {

--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -20,9 +20,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.sentry.Sentry;
+import io.sentry.SentryAttribute;
+import io.sentry.SentryAttributes;
 import io.sentry.UserFeedback;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.SentryLevel;
+import io.sentry.SentryLogLevel;
+import io.sentry.logger.SentryLogParameters;
 import io.sentry.protocol.Feedback;
 import io.sentry.protocol.SentryException;
 import io.sentry.protocol.SentryId;
@@ -165,6 +169,16 @@ public class MyApplication extends Application {
         boolean darkMode = Math.random() > 0.5;
         Sentry.addFeatureFlag("enable-dark-mode", darkMode);
         Sentry.addFeatureFlag("new-checkout-flow", "enterprise".equals(customerType));
+
+        Sentry.logger().log(
+            SentryLogLevel.INFO,
+            SentryLogParameters.create(SentryAttributes.of(
+                SentryAttribute.named("customer.plan", customerType),
+                SentryAttribute.named("customer.email", email),
+                SentryAttribute.named("dark_mode", darkMode)
+            )),
+            "App initialized for %s customer", customerType
+        );
     }
 
     private void launchUserFeedback(SentryId sentryId) {

--- a/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
+++ b/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
@@ -41,11 +41,7 @@ import io.sentry.Attachment;
 import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.Sentry;
-import io.sentry.SentryAttribute;
-import io.sentry.SentryAttributes;
-import io.sentry.SentryLogLevel;
 import io.sentry.SpanStatus;
-import io.sentry.logger.SentryLogParameters;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -324,15 +320,6 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
 
         Sentry.setAttribute("checkout.cart_size", selectedStoreItems.size());
         Sentry.setAttribute("checkout.step", "initiate");
-
-        Sentry.logger().log(
-            SentryLogLevel.INFO,
-            SentryLogParameters.create(SentryAttributes.of(
-                SentryAttribute.named("cart.item_count", selectedStoreItems.size()),
-                SentryAttribute.named("checkout.step", "initiate")
-            )),
-            "Checkout started with %d items", selectedStoreItems.size()
-        );
 
         ITransaction checkoutTransaction = Sentry.startTransaction("checkout [android]", "http.client");
         checkoutTransaction.setOperation("http");

--- a/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
+++ b/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
@@ -41,7 +41,11 @@ import io.sentry.Attachment;
 import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.Sentry;
+import io.sentry.SentryAttribute;
+import io.sentry.SentryAttributes;
+import io.sentry.SentryLogLevel;
 import io.sentry.SpanStatus;
+import io.sentry.logger.SentryLogParameters;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -320,6 +324,15 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
 
         Sentry.setAttribute("checkout.cart_size", selectedStoreItems.size());
         Sentry.setAttribute("checkout.step", "initiate");
+
+        Sentry.logger().log(
+            SentryLogLevel.INFO,
+            SentryLogParameters.create(SentryAttributes.of(
+                SentryAttribute.named("cart.item_count", selectedStoreItems.size()),
+                SentryAttribute.named("checkout.step", "initiate")
+            )),
+            "Checkout started with %d items", selectedStoreItems.size()
+        );
 
         ITransaction checkoutTransaction = Sentry.startTransaction("checkout [android]", "http.client");
         checkoutTransaction.setOperation("http");

--- a/app/src/main/java/com/example/vu/android/empowerplant/StoreItemDetailActivity.kt
+++ b/app/src/main/java/com/example/vu/android/empowerplant/StoreItemDetailActivity.kt
@@ -31,8 +31,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import io.sentry.Sentry
+import io.sentry.SentryAttribute
+import io.sentry.SentryAttributes
+import io.sentry.SentryLogLevel
 import io.sentry.compose.SentryModifier.sentryTag
 import io.sentry.compose.SentryTraced
+import io.sentry.logger.SentryLogParameters
 
 class StoreItemDetailActivity : ComponentActivity() {
     companion object {
@@ -47,6 +51,16 @@ class StoreItemDetailActivity : ComponentActivity() {
         Sentry.setAttribute("screen", "item_detail")
         Sentry.setAttribute("item.sku", storeItem.sku)
         Sentry.metrics().count("product.viewed")
+
+        Sentry.logger().log(
+            SentryLogLevel.INFO,
+            SentryLogParameters.create(SentryAttributes.of(
+                SentryAttribute.named("item.sku", storeItem.sku),
+                SentryAttribute.named("item.name", storeItem.name),
+                SentryAttribute.integerAttribute("item.price", storeItem.price)
+            )),
+            "Product viewed: %s", storeItem.name
+        )
 
         setContent {
             MaterialTheme {
@@ -108,7 +122,7 @@ fun StoreItemDetailScreen(storeItem: StoreItem, onBack: () -> Unit) {
                 }
                 SentryTraced("item_details_price") {
                     Text(
-                        text = "Price: $${storeItem.price}",
+                        text = "Price: \$${storeItem.price}",
                         fontSize = 16.sp,
                         modifier = Modifier.padding(top = 8.dp)
                     )

--- a/app/src/main/java/com/example/vu/android/empowerplant/StoreItemDetailActivity.kt
+++ b/app/src/main/java/com/example/vu/android/empowerplant/StoreItemDetailActivity.kt
@@ -31,12 +31,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import io.sentry.Sentry
-import io.sentry.SentryAttribute
-import io.sentry.SentryAttributes
-import io.sentry.SentryLogLevel
 import io.sentry.compose.SentryModifier.sentryTag
 import io.sentry.compose.SentryTraced
-import io.sentry.logger.SentryLogParameters
 
 class StoreItemDetailActivity : ComponentActivity() {
     companion object {
@@ -51,16 +47,6 @@ class StoreItemDetailActivity : ComponentActivity() {
         Sentry.setAttribute("screen", "item_detail")
         Sentry.setAttribute("item.sku", storeItem.sku)
         Sentry.metrics().count("product.viewed")
-
-        Sentry.logger().log(
-            SentryLogLevel.INFO,
-            SentryLogParameters.create(SentryAttributes.of(
-                SentryAttribute.named("item.sku", storeItem.sku),
-                SentryAttribute.named("item.name", storeItem.name),
-                SentryAttribute.integerAttribute("item.price", storeItem.price)
-            )),
-            "Product viewed: %s", storeItem.name
-        )
 
         setContent {
             MaterialTheme {


### PR DESCRIPTION
## Summary

Bumps the Sentry Android Gradle Plugin from **6.10.0 → 6.15.0**, pins the SDK to **8.49.0**, and bumps `sentry-native-ndk` from **0.14.2 → 0.15.3**.

Supersedes #233 (which covered 6.10.0 → 6.13.0 / SDK 8.46.0) and #227 (6.10.0 → 6.12.0 / SDK 8.44.1).

## Version Changes

| Component | Old | New |
|-----------|-----|-----|
| Sentry Android Gradle Plugin | 6.10.0 | 6.15.0 |
| Sentry Android SDK (auto-installed) | ~8.43.1 | 8.49.0 (pinned via `autoInstallation`) |
| sentry-native-ndk | 0.14.2 | 0.15.3 |

## Changelogs

- [Gradle plugin 6.15.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6150)
- [Gradle plugin 6.14.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6140)
- [Gradle plugin 6.13.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6130)
- [Gradle plugin 6.12.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6120)
- [Gradle plugin 6.11.0](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md#6110)
- [SDK 8.49.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8490)
- [SDK 8.48.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8480)
- [SDK 8.47.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8470)
- [SDK 8.46.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8460)
- [SDK 8.45.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8450)
- [SDK 8.44.0](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8440)
- [SDK 8.43.2](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8432)
- [sentry-native 0.15.3](https://github.com/getsentry/sentry-native/releases/tag/0.15.3)

## New features implemented

1. **Standalone App Start Tracing** (SDK 8.44.0) — Enabled via `io.sentry.standalone-app-start-tracing.enable` manifest entry. The SDK emits a dedicated "App Start" transaction with measurements and phase spans, sharing the same `traceId` as the first activity transaction. On Android 15+ (SDK 8.45.0), this also reports the OS process startup reason via `app.vitals.start.reason`.

2. **Extended App Start API** (SDK 8.48.0) — Uses `Sentry.extendAppStart()` / `Sentry.finishExtendedAppStart()` / `Sentry.getExtendedAppStartSpan()` to extend the app start measurement past the first frame draw. The post-init setup work (tags, user config, attributes, feature flags) is captured as an `app.init` child span on the app start transaction in `MyApplication.onCreate()`.

3. **Historical Tombstone Reporting via Manifest** (SDK 8.48.0) — Added `io.sentry.tombstone.report-historical` manifest entry to enable reporting of historical tombstones (native crash reports) found on disk at startup.

4. **Auto SQLiteDriver Instrumentation** (Plugin 6.13.0) — Automatic via the plugin's `tracingInstrumentation` feature (already enabled). Room database queries now get tracing spans without code changes.

5. **Session Replay Segment Names** (SDK 8.49.0) — The SDK now automatically records transaction names as segment names in Session Replay recordings. No code changes required — comes with the SDK bump.

6. **`sizeAnalysis` Marked Stable** (Plugin 6.15.0) — The `@Experimental` annotation was removed from the `sizeAnalysis` extension, which is already configured in `build.gradle`.

7. **SDK pinned to 8.49.0** — Added `autoInstallation { sentryVersion.set("8.49.0") }` in the `sentry {}` block to pick up the latest Session Replay improvements, performance fixes, and extended app start API.

## What's in the bump (highlights)

**Plugin 6.15.0:** `sizeAnalysis` marked stable, OpenTelemetry version downgrade detection (fails build if OTel deps drop below requirements — can be disabled, not relevant for this app).

**Plugin 6.14.0:** Dependencies only — Android SDK bumped to v8.47.0, CLI to v3.6.0.

**Plugin 6.13.0:** Auto-instrument `SQLiteDriver` for Room users — wraps `SupportSQLiteOpenHelper` automatically.

**Plugin 6.11.0-6.12.0:** CLI bump to v3.5.1, config cache fixes, Linux ARM64 sentry-cli path normalization.

**SDK 8.49.0:** Session Replay records segment/transaction names, logs/metrics flush race fix, tombstone thread identification fix, performance improvements (shared executor for transaction timeouts), native SDK bumped to 0.15.3.

**SDK 8.48.0:** Extended App Start API (`extendAppStart`/`finishExtendedAppStart`/`getExtendedAppStartSpan`), `io.sentry.tombstone.report-historical` manifest option, NDK heartbeat-based app-hang detection (hybrid SDK feature), performance improvements (skip Hint allocation, faster scope persistence, remove executor prewarm).

**SDK 8.46.0-8.47.0:** Major performance improvements — reduced writer buffer sizes, optimized JSON serialization, reduced breadcrumb allocation overhead, faster timestamp parsing, reduced Android startup overhead.

**SDK 8.45.0:** Standalone `app.start` transaction reports OS process startup reason on Android 15+.

**SDK 8.44.0:** `enableStandaloneAppStartTracing` option for dedicated app start transactions.

**SDK 8.43.2:** DSN parsing performance improvement, Session Replay Compose masking fixes.

**sentry-native 0.15.0-0.15.3:** Symbol name resolution fixes, in-process app-hang detection, partial disk write fixes, breadcrumb data as structured objects.

## Features already covered in the codebase

- **Feature Flags API** (`Sentry.addFeatureFlag`) — `MyApplication.java` with `enable-dark-mode` and `new-checkout-flow`
- **Scope Attributes API** (`Sentry.setAttribute`) — across `MyApplication.java`, `MainFragment.java`, `StoreItemDetailActivity.kt`, `EmpowerPlantActivity.java`
- **Metrics API** (`Sentry.metrics()`) — counters for `app.launched`, `product.viewed`, `checkout.attempted`; distribution for `checkout.cart_size`
- **User Feedback** (`Sentry.feedback()`) — `MyApplication.java` with shake gesture enabled
- **Tombstones** — enabled via manifest entries
- **ANR profiling** — enabled via `io.sentry.anr.profiling.sample-rate`
- **Historical ANR reporting** — enabled via `io.sentry.anr.report-historical`
- **Sentry Logs** — enabled via `options.getLogs().setEnabled(true)`
- **Session Replay** — configured at 100% sample rates
- **Logcat forwarding** — enabled via `tracingInstrumentation { logcat { enabled = true } }`

## Features skipped

1. **NDK App Hang Tracking** (SDK 8.48.0) — Requires manual calls to `sentry_app_hang_heartbeat()` from native code on the monitored thread. This is designed for hybrid SDKs (Flutter, React Native) that have their own UI thread heartbeat mechanism. A pure Java/Kotlin Android app uses the JVM-based ANR detection (`setAnrEnabled`), which is already active.

2. **`SentrySQLiteDriver`** (SDK 8.44.1, experimental) — Requires `androidx.sqlite:sqlite` 2.5.0+ with the new `SQLiteDriver` interface. The app uses Room 2.6.1 with the legacy `SupportSQLiteOpenHelper` API; upgrading to Room 2.7+ would be required, and the project has an explicit warning against Room upgrades due to Saucelabs test compatibility. The plugin 6.13.0 auto-instrumentation for `SupportSQLiteOpenHelper` covers this automatically.

3. **sentry-native opt-in async crash upload** (native 0.15.0) — This is a native C API feature (`sentry_options_set_async_crash_upload`) not exposed through the Android Java SDK.

4. **`trace_metric_byte` data category** (SDK 8.48.0) — Internal SDK telemetry for client reports, not a user-facing API.

5. **`ReplayFrameObserver`** (SDK 8.43.0) — Development/debugging API for observing captured replay frames, not a user-facing feature. Session Replay is already fully configured.

6. **`sentry-opentelemetry-bom`** (SDK 8.49.0) — BOM for aligning Sentry OpenTelemetry modules. Not applicable to Android — OpenTelemetry integration is for Spring Boot / JVM server applications.

7. **OpenTelemetry version verification** (Plugin 6.15.0) — The `verifySentryOpenTelemetryVersions` task detects when OpenTelemetry dependencies are downgraded below Sentry's requirements. Not applicable — this Android app does not use OpenTelemetry.

8. **Spring/JVM-only features** (Logback, JUL, Log4j2, Ktor, Kafka, JCache, Spring Boot 4, JVM continuous profiling, OpenTelemetry modules) — Not applicable to Android.

## Build verification

Build could not be fully verified in the CI environment due to network restrictions (403 from Gradle distribution servers). The changes are version bumps, manifest entries, and straightforward SDK API calls — structurally sound.

## Files changed

- `app/build.gradle` — Plugin 6.10.0→6.15.0, sentry-native-ndk 0.14.2→0.15.3, added `autoInstallation` block pinning SDK to 8.49.0
- `app/src/main/AndroidManifest.xml` — Added `io.sentry.standalone-app-start-tracing.enable` and `io.sentry.tombstone.report-historical` meta-data entries
- `app/src/main/java/com/example/vu/android/MyApplication.java` — Added Extended App Start API calls (`extendAppStart`, `getExtendedAppStartSpan`, `finishExtendedAppStart`) wrapping post-init setup as an `app.init` child span