### PR TITLE
Bump Sentry Gradle plugin 6.16.0, SDK 8.50.1, native-ndk 0.15.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.15.0"
+    id "io.sentry.android.gradle" version "6.16.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.15.3'
+    implementation 'io.sentry:sentry-native-ndk:0.15.4'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -142,7 +142,7 @@ tasks.withType(Test) {
 
 sentry {
     autoInstallation {
-        sentryVersion.set("8.49.0")
+        sentryVersion.set("8.50.1")
     }
     autoUpload = true
     uploadNativeSymbols = true


### PR DESCRIPTION
## Summary

Bumps Sentry dependencies to latest stable versions:

| Dependency | Old | New |
|---|---|---|
| Sentry Android Gradle Plugin | 6.15.0 | 6.16.0 |
| Sentry Android SDK (auto-installed) | 8.49.0 | 8.50.1 |
| sentry-native-ndk | 0.15.3 | 0.15.4 |

## Changelogs

- **Gradle Plugin 6.16.0**: [Releases](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.16.0)
- **SDK 8.50.0**: [Releases](https://github.com/getsentry/sentry-java/releases/tag/8.50.0) — Android 17 support
- **SDK 8.50.1**: [Releases](https://github.com/getsentry/sentry-java/releases/tag/8.50.1) — Fix `minCompileSdk` AAR metadata for AGP 9
- **sentry-native 0.15.4**: [Releases](https://github.com/getsentry/sentry-native/releases/tag/0.15.4)

## New features implemented

None — the features in this version range do not require demo app code changes:

- **Plugin 6.16.0** adds automatic `canvas_theme` metadata to Compose `@Preview` snapshot uploads — this is handled entirely by the plugin with no code changes needed.
- **SDK 8.50.0** adds Android 17 compatibility — this is a compatibility/testing milestone, not a new API to exercise.
- **SDK 8.50.1** is a fix-only release (pins `minCompileSdk` in AAR metadata).
- **sentry-native 0.15.4** adds C-level API functions (reusable scopes, `sentry_transaction_discard`, `sentry_span_discard`) and `NativeScope.setEnvironment()` NDK binding — these are native SDK internals not directly exercised from Java/Kotlin demo code. Session replay breadcrumb embedding in crash recordings is automatic.

## Features skipped (with technical blockers)

- **Reusable scopes / scope attributes (sentry-native 0.15.4)**: C API functions (`sentry_scope_new`, `sentry_scope_clone`, etc.) — not exposed through the Java/Kotlin Android SDK; only usable from native C code.
- **Transaction/span discard (sentry-native 0.15.4)**: C API functions — not exposed through the Java/Kotlin Android SDK.
- **NativeScope.setEnvironment() (sentry-native 0.15.4)**: NDK-level binding; environment is already set at the SDK level via `SentryOptions` and synced via `io.sentry.ndk.scope-sync.enable=true` in the manifest.

## Build verification

Build could not be verified in the CI-less remote environment — `./gradlew assembleDebug` fails with 403 from `dl.google.com` due to network restrictions in the execution environment. This is an infrastructure issue, not a code issue. The changes are version-only bumps in `app/build.gradle` with no logic changes."

---
_Generated by [Claude Code](https://claude.ai/code/session_013hKLV2BD6wiWhJ1jNoGNvm)_