### PR TITLE
Bump Sentry Gradle plugin 6.17.0, SDK 8.51.0, native-ndk 0.16.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.15.0"
+    id "io.sentry.android.gradle" version "6.17.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.15.3'
+    implementation 'io.sentry:sentry-native-ndk:0.16.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -142,7 +142,7 @@ tasks.withType(Test) {
 
 sentry {
     autoInstallation {
-        sentryVersion.set("8.49.0")
+        sentryVersion.set("8.51.0")
     }
     autoUpload = true
     uploadNativeSymbols = true


### PR DESCRIPTION
## Summary

Bumps Sentry dependencies to latest stable versions:

| Dependency | Old | New |
|---|---|---|
| Sentry Android Gradle Plugin | 6.15.0 | 6.17.0 |
| Sentry Android SDK (auto-installed) | 8.49.0 | 8.51.0 |
| sentry-native-ndk | 0.15.3 | 0.16.0 |

## Changelogs

- **Gradle Plugin 6.16.0**: [Release](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.16.0) — Emit `canvas_theme` in Compose snapshot metadata
- **Gradle Plugin 6.17.0**: [Release](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.17.0) — CLI v3.6.2, SDK v8.51.0, security fix for self-hosted auth tokens
- **SDK 8.50.0**: [Release](https://github.com/getsentry/sentry-java/releases/tag/8.50.0) — Android 17 support
- **SDK 8.50.1**: [Release](https://github.com/getsentry/sentry-java/releases/tag/8.50.1) — Fix `minCompileSdk` AAR metadata for AGP 9
- **SDK 8.51.0**: [Release](https://github.com/getsentry/sentry-java/releases/tag/8.51.0) — Perfetto-based continuous profiling on API 35+, performance improvements
- **sentry-native 0.16.0**: [Release](https://github.com/getsentry/sentry-native/releases/tag/0.16.0) — Minidump flags, WER integration, user feedback enhancements

## New features implemented

None — no features in this version range require demo app code changes. The demo app already exercises all demonstrable SDK capabilities. Details below.

## Features in the version range (no code changes needed)

- **SDK 8.51.0 — Perfetto continuous profiling on API 35+**: On API 35+ devices, continuous profiling now automatically uses Android's system `ProfilingManager` with Perfetto-based stack sampling. No configuration change is required — the demo app's existing continuous profiling setup (manifest flags + `InitContentProvider`) works seamlessly. The new `enableLegacyProfiling` option defaults to `true`, preserving legacy profiler support on API < 35 devices. Setting it to `false` is not appropriate for this demo since it would disable profiling on older devices.
- **Plugin 6.16.0 — `canvas_theme` metadata**: Automatically emitted by the plugin for Compose `@Preview` snapshots; entirely plugin-internal with no code changes needed.
- **SDK 8.50.0 — Android 17 support**: Compatibility milestone, not a new API to exercise.
- **SDK 8.50.1**: Fix-only release (AAR metadata for AGP 9).
- **Plugin 6.17.0**: Dependency updates + security fix for self-hosted auth token handling (not applicable to this demo).

## Features skipped (with technical blockers)

- **sentry-native 0.15.4 → 0.16.0 features**: All new features are C-level APIs (minidump flags, WER integration, scope-based feedback, cache overflow reporting) or Windows-specific. These are not exposed through the Java/Kotlin Android SDK and cannot be exercised from demo app code.

## Supersedes

This PR supersedes #246 which bumped to intermediate versions (plugin 6.16.0, SDK 8.50.1, native-ndk 0.15.4).

## Build verification

Build could not be fully verified in the remote environment — `./gradlew assembleDebug` fails with 403 from `dl.google.com` due to network restrictions. This is an infrastructure limitation, not a code issue. The changes are version-only bumps in `app/build.gradle` with no logic changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7p9pRHqiJ1MiicFQiYAVr)_