### PR TITLE
Bump Sentry Gradle plugin 6.18.0, SDK 8.52.0, native-ndk 0.16.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.17.0"
+    id "io.sentry.android.gradle" version "6.18.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.16.0'
+    implementation 'io.sentry:sentry-native-ndk:0.16.1'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -142,7 +142,7 @@ tasks.withType(Test) {
 
 sentry {
     autoInstallation {
-        sentryVersion.set("8.51.0")
+        sentryVersion.set("8.52.0")
     }
     autoUpload = true
     uploadNativeSymbols = true


### PR DESCRIPTION
## Summary

Bumps Sentry dependencies to latest stable versions:

| Dependency | Old | New |
|---|---|---|
| Sentry Android Gradle Plugin | 6.17.0 | 6.18.0 |
| Sentry Android SDK (auto-installed) | 8.51.0 | 8.52.0 |
| sentry-native-ndk | 0.16.0 | 0.16.1 |

## Changelogs

### Gradle Plugin 6.18.0
- [Release notes](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.18.0)
- **Fix:** Support ProGuard mapping tasks when R8 is enabled with the AGP `optimization.enable` DSL
- **Performance:** Eliminate reflection for known optional Sentry SDK class-availability checks, reducing SDK initialization time by ~1%. Enabled by default via `sentry.runtimeOptimizations.enabled` (no code change needed).
- **Dependencies:** Android SDK bumped from v8.51.0 to v8.52.0

### SDK 8.52.0
- [Release notes](https://github.com/getsentry/sentry-java/releases/tag/8.52.0)
- **Fixes:** Clear contexts on `Scope.clear()`, preserve custom Throwable identities under R8, reduce false-positive SDK crash attribution for SQLite cursor crashes, prevent inflated cold app start from background process spawning, preserve single-sample ANR profile chunks, avoid CPU busy-loop under rate limiting
- **Performance:** Defer reflection during SDK init, use `RGB_565` for screenshot/replay capture (halving per-frame memory), batch scope-persistence disk writes, reduce SDK thread count
- **Dependencies:** Native SDK bumped from v0.16.0 to v0.16.1

### sentry-native 0.16.1
- [Release notes](https://github.com/getsentry/sentry-native/releases/tag/0.16.1)
- **Feature:** Added `sentry_app_hang_pause` C API for pausing app hang detection (not exposed in Java/Kotlin SDK)
- **Fix:** Honor checks before launching crash reporter

## New features implemented

None — the changelog entries in this version range contain only fixes, performance improvements, and C-level native APIs:

- **Plugin 6.18.0** `runtimeOptimizations` — enabled by default, no code change needed. The optimization eliminates reflection for SDK class-availability checks at build time.
- **SDK 8.52.0** — all entries are fixes and performance improvements, no new user-facing APIs.
- **sentry-native 0.16.1** `sentry_app_hang_pause` — C-level API not exposed through the Java/Kotlin Android SDK.

## Features skipped (with technical blockers)

- **`sentry_app_hang_pause` (sentry-native 0.16.1):** C API function not exposed through the Java/Kotlin Android SDK; only usable from native C code.

## Build verification

Build could not be fully verified — `./gradlew assembleDebug` fails with HTTP 403 from `dl.google.com` due to network restrictions in the remote execution environment. This is an infrastructure issue, not a code issue. The changes are version-only bumps in `app/build.gradle` with no logic changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_013uTx5wwpDc8G4K3obxgjc8)_