### PR TITLE
Bump Sentry Gradle plugin 6.19.0, SDK 8.53.0, native-ndk 0.16.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.17.0"
+    id "io.sentry.android.gradle" version "6.19.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.16.0'
+    implementation 'io.sentry:sentry-native-ndk:0.16.3'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -142,7 +142,7 @@ tasks.withType(Test) {
 
 sentry {
     autoInstallation {
-        sentryVersion.set("8.51.0")
+        sentryVersion.set("8.53.0")
     }
     autoUpload = true
     uploadNativeSymbols = true

--- a/app/src/main/java/com/example/vu/android/MyApplication.java
+++ b/app/src/main/java/com/example/vu/android/MyApplication.java
@@ -174,6 +174,12 @@ public class MyApplication extends Application {
         Sentry.addFeatureFlag("enable-dark-mode", darkMode);
         Sentry.addFeatureFlag("new-checkout-flow", "enterprise".equals(customerType));
 
+        if ("enterprise".equals(customerType)) {
+            Sentry.feedback().enableOnShake();
+        } else {
+            Sentry.feedback().disableOnShake();
+        }
+
         if (initChild != null) {
             initChild.finish();
         }

--- a/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
+++ b/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
@@ -41,6 +41,9 @@ import io.sentry.Attachment;
 import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.Sentry;
+import io.sentry.SentryDate;
+import io.sentry.SentryNanotimeDate;
+import io.sentry.SpanOptions;
 import io.sentry.SpanStatus;
 
 import okhttp3.Call;
@@ -323,6 +326,7 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
 
         ITransaction checkoutTransaction = Sentry.startTransaction("checkout [android]", "http.client");
         checkoutTransaction.setOperation("http");
+        SentryDate cartProcessingStart = new SentryNanotimeDate();
         Sentry.configureScope(scope -> scope.setTransaction(checkoutTransaction));
 
         Log.v("checkout", "showing dialog");
@@ -331,7 +335,9 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
         progressDialog.setMessage("Checking Out...");
         progressDialog.show();
 
-        ISpan processDataSpan = checkoutTransaction.startChild("task", "process_cart_data");
+        SpanOptions spanOptions = new SpanOptions();
+        spanOptions.setStartTimestamp(cartProcessingStart);
+        ISpan processDataSpan = checkoutTransaction.startChild("task", "process_cart_data", spanOptions);
         JSONObject object = this.buildJSONPostData(selectedStoreItems);
         try {
             Thread.sleep(500);


### PR DESCRIPTION
## Summary

Bumps Sentry dependencies to latest stable versions:

| Dependency | Old | New |
|---|---|---|
| Sentry Android Gradle Plugin | 6.17.0 | 6.19.0 |
| Sentry Android SDK (auto-installed) | 8.51.0 | 8.53.0 |
| sentry-native-ndk | 0.16.0 | 0.16.3 |

## Changelogs

### Gradle Plugin 6.17.0 → 6.19.0
- [6.18.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.18.0) — Fix ProGuard mapping with AGP `optimization.enable` DSL; eliminate reflection for SDK class-availability checks (~1% init time reduction, enabled by default via `runtimeOptimizations`)
- [6.19.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.19.0) — Fix AGP `optimization.enable` detection when variant is wrapped by AGP analytics

### SDK 8.51.0 → 8.53.0
- [8.52.0](https://github.com/getsentry/sentry-java/releases/tag/8.52.0) — Fixes and performance: clear contexts on `Scope.clear()`, halve screenshot/replay memory via `RGB_565`, batch scope-persistence disk writes, reduce SDK thread count, prevent cold app start inflation on API 35+
- [8.53.0](https://github.com/getsentry/sentry-java/releases/tag/8.53.0) — **Features:** allow child spans to use explicit start timestamps via `SpanOptions`; make `ISpan.startChild` overloads with `SpanOptions` public; runtime toggle of shake-to-report via `Sentry.feedback().enableOnShake()`/`disableOnShake()`/`isOnShakeEnabled()`. Fixes: prevent ANR when Session Replay video encoder gets stuck; optimize CPU usage collection

### sentry-native 0.16.0 → 0.16.3
- [0.16.1](https://github.com/getsentry/sentry-native/releases/tag/0.16.1) — C API: `sentry_app_hang_pause`; fix crash reporter config checks
- [0.16.2](https://github.com/getsentry/sentry-native/releases/tag/0.16.2) — C API: `sentry_scope_remove_fingerprint`, `sentry_options_set_before_send_feedback`; fixes for FD leak, Crashpad init ordering
- [0.16.3](https://github.com/getsentry/sentry-native/releases/tag/0.16.3) — Forward `enable_logs` option through `NdkOptions` (automatic with SDK logs enabled); C API: `sentry_scope_set_span`/`sentry_scope_set_transaction_object`; Crashpad attachment path fix

## New features implemented

1. **Runtime shake-to-report toggle** (SDK 8.53.0) — In `MyApplication.onCreate()`, shake-to-report is now conditionally enabled at runtime based on customer plan: enterprise customers get `Sentry.feedback().enableOnShake()`, all other plans get `Sentry.feedback().disableOnShake()`. The manifest default (`io.sentry.feedback.use-shake-gesture=true`) is overridden at runtime. This demonstrates the new runtime toggle API introduced in 8.53.0.

2. **SpanOptions with explicit start timestamps** (SDK 8.53.0) — In `MainFragment.checkout()`, a `SentryDate` is captured right after the checkout transaction starts (before scope configuration and dialog setup). A `SpanOptions` object passes this timestamp as the explicit start time for the `process_cart_data` child span, so the span timing accurately reflects the full checkout setup duration. This demonstrates both newly public APIs: `SpanOptions.setStartTimestamp()` and `ISpan.startChild(operation, description, SpanOptions)`.

## Features skipped (with technical blockers)

- **`sentry_app_hang_pause`** (sentry-native 0.16.1) — C API not exposed through the Java/Kotlin Android SDK
- **`sentry_scope_remove_fingerprint`** (sentry-native 0.16.2) — C API not exposed through the Java/Kotlin Android SDK
- **`sentry_options_set_before_send_feedback`** (sentry-native 0.16.2) — C API not exposed through the Java/Kotlin Android SDK
- **`SENTRY_LINK_CURL`** (sentry-native 0.16.2) — Unix build-time option, not relevant to Android
- **`sentry_scope_set_span` / `sentry_scope_set_transaction_object`** (sentry-native 0.16.3) — C API not exposed through the Java/Kotlin Android SDK
- **Qt/WER integration reporting** (sentry-native 0.16.3) — Not relevant to Android platform
- **Forward `enable_logs` through `NdkOptions`** (sentry-native 0.16.3) — Automatic; `options.getLogs().setEnabled(true)` is already set in `MyApplication`, so the NDK option is forwarded without code changes

## Build verification

Build could not be fully verified — `./gradlew assembleDebug` fails with HTTP 403 from `dl.google.com` due to network restrictions in the remote execution environment. This is an infrastructure issue, not a code issue. The Gradle plugin version, SDK version, and native-ndk version bumps are straightforward dependency updates, and the new API calls (`Sentry.feedback().enableOnShake()`/`disableOnShake()`, `SpanOptions`, `SentryNanotimeDate`, `ISpan.startChild` with `SpanOptions`) were verified against the [sentry-java 8.53.0 source](https://github.com/getsentry/sentry-java/tree/8.53.0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE1wS5EcdUjXkrAGvcfdpD)_