### PR TITLE
Document that app start profiling is legacy-profiler only

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,11 @@
         <meta-data
             android:name="io.sentry.traces.profiling.lifecycle"
             android:value="trace" />
+        <!-- App start profiling is only supported by the legacy profiler, i.e. on devices
+             below Android 15 (API level 35). On API 35+ the SDK uses the platform
+             ProfilingManager (Perfetto) backend and this option has no effect. Kept enabled
+             because minSdkVersion is 21, so the app still runs where it does apply. -->
+        <!-- https://docs.sentry.io/platforms/android/profiling/#limitations -->
         <meta-data
             android:name="io.sentry.traces.profiling.start-on-app-start"
             android:value="true" />


### PR DESCRIPTION
## Why

While pinning the empower TDA Android emulator to Android 15 (`sentry-demos/empower`), I hit the [profiling limitations](https://docs.sentry.io/platforms/android/profiling/#limitations) for API level 35+:

> App start profiling is not supported. The `startProfilerOnAppStart` option has no effect with the ProfilingManager (Perfetto) backend. App start profiling is only supported by the legacy profiler used on devices below Android 15.

This manifest sets `io.sentry.traces.profiling.start-on-app-start` to `true`, which reads as "app start profiling is on" — but on API 35+ it does nothing. Anyone demoing on a modern device and not seeing an app start profile has no way to tell that from the manifest.

## What

Comment only — no behavior change. The meta-data **stays enabled**: `minSdkVersion` is 21, so the app still runs on plenty of devices below API 35 where the legacy profiler honors it. Removing it would have silently dropped app start profiling on exactly those devices.

## Related

`setup_profiling_device.sh` (#253) already covers the other API 35+ limitation — the framework rate limiter. This documents the remaining one in the place people actually read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)