### PR TITLE
Bump Sentry Gradle plugin 6.20.0, SDK 8.54.0, native-ndk 0.16.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.17.0"
+    id "io.sentry.android.gradle" version "6.20.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.16.0'
+    implementation 'io.sentry:sentry-native-ndk:0.16.4'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -142,7 +142,7 @@ tasks.withType(Test) {
 
 sentry {
     autoInstallation {
-        sentryVersion.set("8.51.0")
+        sentryVersion.set("8.54.0")
     }
     autoUpload = true
     uploadNativeSymbols = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,6 +103,9 @@
             android:name="io.sentry.feedback.use-shake-gesture"
             android:value="true" />
         <meta-data
+            android:name="io.sentry.feedback.enable-attach-screenshot"
+            android:value="true" />
+        <meta-data
             android:name="io.sentry.anr.profiling.sample-rate"
             android:value="1.0" />
         <meta-data

--- a/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
+++ b/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
@@ -41,6 +41,9 @@ import io.sentry.Attachment;
 import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.Sentry;
+import io.sentry.SentryDate;
+import io.sentry.SentryNanotimeDate;
+import io.sentry.SpanOptions;
 import io.sentry.SpanStatus;
 
 import okhttp3.Call;
@@ -322,6 +325,7 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
         Sentry.setAttribute("checkout.step", "initiate");
 
         ITransaction checkoutTransaction = Sentry.startTransaction("checkout [android]", "http.client");
+        SentryDate cartProcessingStart = new SentryNanotimeDate();
         checkoutTransaction.setOperation("http");
         Sentry.configureScope(scope -> scope.setTransaction(checkoutTransaction));
 
@@ -331,7 +335,9 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
         progressDialog.setMessage("Checking Out...");
         progressDialog.show();
 
-        ISpan processDataSpan = checkoutTransaction.startChild("task", "process_cart_data");
+        SpanOptions spanOptions = new SpanOptions();
+        spanOptions.setStartTimestamp(cartProcessingStart);
+        ISpan processDataSpan = checkoutTransaction.startChild("task", "process_cart_data", spanOptions);
         JSONObject object = this.buildJSONPostData(selectedStoreItems);
         try {
             Thread.sleep(500);
@@ -447,6 +453,7 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
             processDeliverySpan.setStatus(SpanStatus.OK);
         }
         processDeliverySpan.finish();
+        Sentry.replay().flush();
         Log.i("processDeliveryItem", "<<< processDeliveryItem");
     }
 


### PR DESCRIPTION
## Summary

Bumps Sentry dependencies to latest stable versions:

| Dependency | Old | New |
|---|---|---|
| Sentry Android Gradle Plugin | 6.17.0 | 6.20.0 |
| Sentry Android SDK (auto-installed) | 8.51.0 | 8.54.0 |
| sentry-native-ndk | 0.16.0 | 0.16.4 |

## Changelogs

### Gradle Plugin 6.17.0 → 6.20.0
- [6.18.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.18.0) — Fix ProGuard mapping with AGP `optimization.enable` DSL; eliminate reflection for SDK class-availability checks (~1% init time reduction, enabled by default via `runtimeOptimizations`)
- [6.19.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.19.0) — Fix AGP `optimization.enable` detection when variant is wrapped by AGP analytics
- [6.20.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.20.0) — Per-variant overrides for tracing instrumentation and runtime optimizations via reverse DSL; resolve Sentry manifest metadata at build time to reduce SDK initialization overhead

### SDK 8.51.0 → 8.54.0
- [8.52.0](https://github.com/getsentry/sentry-java/releases/tag/8.52.0) — Fixes and performance: clear contexts on `Scope.clear()`, halve screenshot/replay memory via `RGB_565`, batch scope-persistence disk writes, reduce SDK thread count, prevent cold app start inflation on API 35+
- [8.53.0](https://github.com/getsentry/sentry-java/releases/tag/8.53.0) — **Features:** allow child spans to use explicit start timestamps via `SpanOptions`; make `ISpan.startChild` overloads with `SpanOptions` public
- [8.54.0](https://github.com/getsentry/sentry-java/releases/tag/8.54.0) — **Features:** manual Session Replay controls via `Sentry.replay()` (`start()`, `stop()`, `pause()`, `resume()`, `flush()`); screenshot attachment for user feedback widget (`io.sentry.feedback.enable-attach-screenshot`); app vitals on standalone `app.start` children

### sentry-native 0.16.0 → 0.16.4
- [0.16.1](https://github.com/getsentry/sentry-native/releases/tag/0.16.1) — C API: `sentry_app_hang_pause`; fix crash reporter config checks
- [0.16.2](https://github.com/getsentry/sentry-native/releases/tag/0.16.2) — C API: `sentry_scope_remove_fingerprint`, `sentry_options_set_before_send_feedback`; fixes for FD leak, Crashpad init ordering
- [0.16.3](https://github.com/getsentry/sentry-native/releases/tag/0.16.3) — Forward `enable_logs` option through `NdkOptions`; C API: `sentry_scope_set_span`/`sentry_scope_set_transaction_object`
- [0.16.4](https://github.com/getsentry/sentry-native/releases/tag/0.16.4) — Custom HTTP transport interface; `sentry_set_tags`/`sentry_get_last_event_id`; `on_crashed_last_run` callback; dynamic libcurl loading

## New features implemented

1. **SpanOptions with explicit start timestamps** (SDK 8.53.0) — In `MainFragment.checkout()`, a `SentryDate` is captured via `SentryNanotimeDate` right after the checkout transaction starts (before scope configuration and dialog setup). A `SpanOptions` object passes this timestamp as the explicit start time for the `process_cart_data` child span, so the span timing accurately reflects the full checkout setup duration. This demonstrates both newly public APIs: `SpanOptions.setStartTimestamp()` and `ISpan.startChild(operation, description, SpanOptions)`.

2. **Manual Session Replay flush** (SDK 8.54.0) — In `MainFragment.processDeliveryItem()`, `Sentry.replay().flush()` is called after the checkout failure exception is captured. This ensures the replay segment around the checkout error is sent immediately rather than waiting for the buffer to fill, demonstrating the new `Sentry.replay()` manual control API.

3. **User Feedback screenshot attachment** (SDK 8.54.0) — Added `io.sentry.feedback.enable-attach-screenshot` = `true` in `AndroidManifest.xml`. This enables the new screenshot attachment capability in the feedback widget (enabled by default in 8.54.0, made explicit here for demo visibility).

## Features skipped (with technical blockers)

- **`sentry_app_hang_pause`** (sentry-native 0.16.1) — C API not exposed through the Java/Kotlin Android SDK
- **`sentry_scope_remove_fingerprint`** / **`sentry_options_set_before_send_feedback`** (sentry-native 0.16.2) — C API not exposed through the Java/Kotlin Android SDK
- **`sentry_scope_set_span`** / **`sentry_scope_set_transaction_object`** (sentry-native 0.16.3) — C API not exposed through the Java/Kotlin Android SDK
- **Forward `enable_logs` through `NdkOptions`** (sentry-native 0.16.3) — Automatic; `options.getLogs().setEnabled(true)` is already set in `MyApplication`, so the NDK option is forwarded without code changes
- **Custom HTTP transport / bulk tags / crash inspection callback / event ID retrieval / dynamic libcurl** (sentry-native 0.16.4) — C-level APIs not exposed through the Java/Kotlin Android SDK; Windows/Unix-specific features not relevant to Android
- **App vitals on standalone spans** (SDK 8.54.0) — Automatic; `io.sentry.standalone-app-start-tracing.enable` is already `true` in the manifest, so `app.vitals.start.screen` and `app.vitals.start.type` are set automatically with no code changes
- **Per-variant tracing overrides** (plugin 6.20.0) — The `variants {}` DSL enables per-variant configuration of tracing instrumentation and runtime optimizations; the app's current global config already applies uniformly to all variants, so no per-variant override is needed
- **Runtime optimizations** (plugin 6.18.0) — Enabled by default; no code change needed

## Build verification

Build could not be fully verified — `./gradlew assembleDebug` fails with HTTP 403 from `dl.google.com` due to network restrictions in the remote execution environment. This is an infrastructure issue, not a code issue. The Gradle plugin version, SDK version, and native-ndk version bumps are straightforward dependency updates, and the new API calls (`SpanOptions`, `SentryNanotimeDate`, `ISpan.startChild` with `SpanOptions`, `Sentry.replay().flush()`) were verified against the sentry-java 8.54.0 release notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKJsBA5EJU1dusSsnCT3yb)_