### PR TITLE
Bump Sentry Gradle plugin 6.21.0, SDK 8.55.0, native-ndk 0.16.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 import io.sentry.android.gradle.instrumentation.logcat.LogcatLevel
 
 plugins {
-    id "io.sentry.android.gradle" version "6.17.0"
+    id "io.sentry.android.gradle" version "6.21.0"
     id 'com.android.application'
     id 'kotlin-android'
     id 'com.ydq.android.gradle.native-aar.import'
@@ -83,7 +83,7 @@ android {
 
 dependencies {
     // This should be included by default in the Android SDK, but it seems to be a problem with v8+ of the SDK, so we have to manually add it
-    implementation 'io.sentry:sentry-native-ndk:0.16.0'
+    implementation 'io.sentry:sentry-native-ndk:0.16.5'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation group: 'androidx.constraintlayout', name: 'constraintlayout', version: '1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
@@ -142,7 +142,7 @@ tasks.withType(Test) {
 
 sentry {
     autoInstallation {
-        sentryVersion.set("8.51.0")
+        sentryVersion.set("8.55.0")
     }
     autoUpload = true
     uploadNativeSymbols = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,6 +103,9 @@
             android:name="io.sentry.feedback.use-shake-gesture"
             android:value="true" />
         <meta-data
+            android:name="io.sentry.feedback.enable-attach-screenshot"
+            android:value="true" />
+        <meta-data
             android:name="io.sentry.anr.profiling.sample-rate"
             android:value="1.0" />
         <meta-data

--- a/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
+++ b/app/src/main/java/com/example/vu/android/empowerplant/MainFragment.java
@@ -41,6 +41,9 @@ import io.sentry.Attachment;
 import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.Sentry;
+import io.sentry.SentryDate;
+import io.sentry.SentryNanotimeDate;
+import io.sentry.SpanOptions;
 import io.sentry.SpanStatus;
 
 import okhttp3.Call;
@@ -313,6 +316,7 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
 
     public void checkout() {
         Log.i("checkout", "checkout >>>");
+        Sentry.feedback().disableOnShake();
         List<StoreItem> selectedStoreItems = AppDatabase.getInstance(MyApplication.appContext).StoreItemDAO().getSelectedItems();
 
         Sentry.metrics().count("checkout.attempted");
@@ -322,6 +326,7 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
         Sentry.setAttribute("checkout.step", "initiate");
 
         ITransaction checkoutTransaction = Sentry.startTransaction("checkout [android]", "http.client");
+        SentryDate cartProcessingStart = new SentryNanotimeDate();
         checkoutTransaction.setOperation("http");
         Sentry.configureScope(scope -> scope.setTransaction(checkoutTransaction));
 
@@ -331,7 +336,9 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
         progressDialog.setMessage("Checking Out...");
         progressDialog.show();
 
-        ISpan processDataSpan = checkoutTransaction.startChild("task", "process_cart_data");
+        SpanOptions spanOptions = new SpanOptions();
+        spanOptions.setStartTimestamp(cartProcessingStart);
+        ISpan processDataSpan = checkoutTransaction.startChild("task", "process_cart_data", spanOptions);
         JSONObject object = this.buildJSONPostData(selectedStoreItems);
         try {
             Thread.sleep(500);
@@ -375,8 +382,11 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
                             processDeliveryItem(checkoutTransaction);
 
                             checkoutTransaction.finish(SpanStatus.INTERNAL_ERROR);
+                            Sentry.feedback().enableOnShake();
                         }
                     });
+                } else {
+                    Sentry.feedback().enableOnShake();
                 }
             }
 
@@ -387,6 +397,7 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
 
                 processDeliveryItem(checkoutTransaction);
                 checkoutTransaction.finish(SpanStatus.INTERNAL_ERROR);
+                Sentry.feedback().enableOnShake();
                 Log.e("checkout", "checkout failed");
             }
         });
@@ -447,6 +458,7 @@ public class MainFragment extends Fragment implements StoreItemAdapter.ItemClick
             processDeliverySpan.setStatus(SpanStatus.OK);
         }
         processDeliverySpan.finish();
+        Sentry.replay().flush();
         Log.i("processDeliveryItem", "<<< processDeliveryItem");
     }
 


### PR DESCRIPTION
## Summary

Bumps Sentry dependencies to latest stable versions:

| Dependency | Old | New |
|---|---|---|
| Sentry Android Gradle Plugin | 6.17.0 | 6.21.0 |
| Sentry Android SDK (auto-installed) | 8.51.0 | 8.55.0 |
| sentry-native-ndk | 0.16.0 | 0.16.5 |

## Changelogs

### Gradle Plugin 6.17.0 → 6.21.0
- [6.18.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.18.0) — Fix ProGuard mapping with AGP `optimization.enable` DSL; eliminate reflection for SDK class-availability checks (~1% init time reduction)
- [6.19.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.19.0) — Fix AGP `optimization.enable` detection when variant is wrapped by AGP analytics
- [6.20.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.20.0) — Per-variant overrides for tracing instrumentation and runtime optimizations via reverse DSL; resolve Sentry manifest metadata at build time to reduce SDK initialization overhead
- [6.21.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/6.21.0) — Fix snapshot task wiring for multi-flavor modules; verify Kotlin compiler plugin build dependencies with PGP signatures

### SDK 8.51.0 → 8.55.0
- [8.52.0](https://github.com/getsentry/sentry-java/releases/tag/8.52.0) — Fixes and performance: halve screenshot/replay memory via `RGB_565`, batch scope-persistence disk writes, reduce SDK thread count, prevent cold app start inflation on API 35+
- [8.53.0](https://github.com/getsentry/sentry-java/releases/tag/8.53.0) — **Features:** explicit start timestamps for child spans via `SpanOptions`; runtime shake-to-report toggle via `Sentry.feedback().enableOnShake()`/`disableOnShake()`
- [8.54.0](https://github.com/getsentry/sentry-java/releases/tag/8.54.0) — **Features:** manual Session Replay controls via `Sentry.replay()` (`start()`, `stop()`, `pause()`, `resume()`, `flush()`); screenshot attachment for user feedback widget; app vitals on standalone `app.start` children
- [8.55.0](https://github.com/getsentry/sentry-java/releases/tag/8.55.0) — **Features:** `Session.State.Unhandled` for unhandled errors that don't terminate the process; single `ui.compose` span per `SentryTraced` on initial composition; ANR profiling moved out of experimental

### sentry-native 0.16.0 → 0.16.5
- [0.16.1–0.16.4](https://github.com/getsentry/sentry-native/releases) — C API additions (`sentry_app_hang_pause`, scope/transport/callback APIs), forward `enable_logs` through `NdkOptions`, various fixes
- [0.16.5](https://github.com/getsentry/sentry-native/releases/tag/0.16.5) — `sentry_crash` for deliberate crash testing, thread stackwalk mode, 68 perf-monitoring functions promoted to stable

## New features implemented

1. **SpanOptions with explicit start timestamps** (SDK 8.53.0) — In `MainFragment.checkout()`, a `SentryDate` is captured via `SentryNanotimeDate` right after the checkout transaction starts (before scope configuration and dialog setup). A `SpanOptions` object passes this timestamp as the explicit start time for the `process_cart_data` child span, so the span timing accurately reflects the full checkout setup duration. Demonstrates both newly public APIs: `SpanOptions.setStartTimestamp()` and `ISpan.startChild(operation, description, SpanOptions)`.

2. **Feedback shake runtime toggle** (SDK 8.53.0) — In `MainFragment.checkout()`, `Sentry.feedback().disableOnShake()` is called at the start of checkout to suppress accidental feedback during the checkout flow. After checkout completes (both success and failure paths), `Sentry.feedback().enableOnShake()` re-enables shake-to-report. This demonstrates the new runtime toggle API with a natural use case: preventing feedback interruptions during critical user flows.

3. **User feedback screenshot attachment** (SDK 8.54.0) — Added `io.sentry.feedback.enable-attach-screenshot` = `true` in `AndroidManifest.xml`. Enables the screenshot attachment button in the feedback widget so users can attach a screenshot when submitting feedback.

4. **Manual Session Replay flush** (SDK 8.54.0) — In `MainFragment.processDeliveryItem()`, `Sentry.replay().flush()` is called after the checkout failure exception is captured. This ensures the replay segment around the checkout error is sent immediately rather than waiting for the buffer to fill.

## Features skipped (with technical blockers)

- **sentry-native C APIs** (`sentry_app_hang_pause`, `sentry_scope_remove_fingerprint`, `sentry_options_set_before_send_feedback`, `sentry_scope_set_span`, `sentry_scope_set_transaction_object`, custom HTTP transport, `sentry_set_tags`, `sentry_crash`, `sentry_options_set_thread_stackwalk_mode`, `sentry_value_foreach_*`) — C-level APIs not exposed through the Java/Kotlin Android SDK
- **Forward `enable_logs` through `NdkOptions`** (sentry-native 0.16.3) — Automatic; `options.getLogs().setEnabled(true)` is already set in `MyApplication`, so the NDK option is forwarded without code changes
- **App vitals on standalone spans** (SDK 8.54.0) — Automatic; `io.sentry.standalone-app-start-tracing.enable` is already `true` in the manifest, so `app.vitals.start.screen` and `app.vitals.start.type` are set automatically with no code changes
- **`Session.State.Unhandled`** (SDK 8.55.0) — Internal SDK behavior for session state tracking; automatically categorizes sessions with unhandled errors that don't crash. No app-level code changes needed.
- **Per-variant tracing overrides** (plugin 6.20.0) — The `variants {}` DSL enables per-variant configuration of tracing instrumentation and runtime optimizations; the app's current global config already applies uniformly to all variants, so no per-variant override is needed
- **Runtime optimizations** (plugin 6.18.0) — Enabled by default; no code change needed
- **Build-time manifest metadata resolution** (plugin 6.20.0) — Automatic optimization; no code change needed

## Build verification

Build could not be fully verified — `./gradlew assembleDebug` fails with HTTP 403 from `dl.google.com` due to network restrictions in the remote execution environment. This is an infrastructure issue, not a code issue. The Gradle plugin version, SDK version, and native-ndk version bumps are straightforward dependency updates, and the new API calls (`SpanOptions`, `SentryNanotimeDate`, `ISpan.startChild` with `SpanOptions`, `Sentry.feedback().disableOnShake()`/`enableOnShake()`, `Sentry.replay().flush()`) were verified against the sentry-java 8.55.0 release notes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExrBPjfodaiBAJaKDmSWBh

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExrBPjfodaiBAJaKDmSWBh)_